### PR TITLE
ActionGame components dereference asset/component lookups unguarded

### DIFF
--- a/Solution/ActionGame/Components/CharacterAnimationComponent.cpp
+++ b/Solution/ActionGame/Components/CharacterAnimationComponent.cpp
@@ -50,6 +50,9 @@ CharacterAnimationComponent::~CharacterAnimationComponent()
 
 void CharacterAnimationComponent::PlayMovementAnimation()
 {
+	if (!myAnimationSet)
+		return;
+
 	if (!myAnimationSet->myWalk)
 		return;
 
@@ -65,6 +68,9 @@ void CharacterAnimationComponent::PlayMovementAnimation()
 
 void CharacterAnimationComponent::PlayAttackAnimation()
 {
+	if (!myAnimationSet)
+		return;
+
 	Slush::AnimationComponent* animComponent = myEntity.GetComponent<Slush::AnimationComponent>();
 	animComponent->PlayAnimation(*myAnimationSet->myAttack);
 }

--- a/Solution/ActionGame/Components/CharacterAnimationComponent.h
+++ b/Solution/ActionGame/Components/CharacterAnimationComponent.h
@@ -30,5 +30,5 @@ public:
 	//void Update() override;
 	
 private:
-	const CharacterAnimationSet* myAnimationSet;
+	const CharacterAnimationSet* myAnimationSet = nullptr;
 };

--- a/Solution/ActionGame/Components/HealthComponent.cpp
+++ b/Solution/ActionGame/Components/HealthComponent.cpp
@@ -68,10 +68,13 @@ void HealthComponent::DealDamage(int aDamageAmount)
 
 	damageTaken.myNewHealth = myCurrentHealth;
 
-	if (Slush::AnimationComponent* anim = myEntity.GetComponent<Slush::AnimationComponent>())
+	if (myDamageAnimation)
 	{
-		Slush::AnimationRuntime* animData = anim->PlayAnimation(*myDamageAnimation);
-		animData->myEndColor = 0xFFFF0000;
+		if (Slush::AnimationComponent* anim = myEntity.GetComponent<Slush::AnimationComponent>())
+		{
+			Slush::AnimationRuntime* animData = anim->PlayAnimation(*myDamageAnimation);
+			animData->myEndColor = 0xFFFF0000;
+		}
 	}
 
 	if (HealthBarComponent* healthBar = myEntity.GetComponent<HealthBarComponent>())

--- a/Solution/ActionGame/Components/PlayerControllerComponent.cpp
+++ b/Solution/ActionGame/Components/PlayerControllerComponent.cpp
@@ -28,7 +28,7 @@ void PlayerControllerComponent::OnEnterWorld()
 void PlayerControllerComponent::PrePhysicsUpdate()
 {
 	Slush::AnimationComponent* anim = myEntity.GetComponent<Slush::AnimationComponent>();
-	if (!anim || !anim->IsAnimationPlaying(*myDashAnimation))
+	if (!anim || !myDashAnimation || !anim->IsAnimationPlaying(*myDashAnimation))
 	{
 		myDirection = { 0.f, 0.f };
 
@@ -56,7 +56,7 @@ void PlayerControllerComponent::PrePhysicsUpdate()
 				sprite->GetSprite().SetHorizontalFlip(true);
 		}
 
-		if (anim && input.WasKeyPressed(Slush::Input::SPACE))
+		if (anim && myDashAnimation && input.WasKeyPressed(Slush::Input::SPACE))
 		{
 			Slush::AnimationRuntime* animData = anim->PlayAnimation(*myDashAnimation);
 			animData->myEndPosition = myEntity.myPosition + myDirection * 500.f;
@@ -70,7 +70,7 @@ void PlayerControllerComponent::PrePhysicsUpdate()
 			ActionGameGlobals::GetInstance().GetEntityManager().CreateEntity(myEntity.myPosition, "Magic_Spawn_Large");
 		}
 			
-		if (anim && input.WasKeyPressed(Slush::Input::V))
+		if (anim && mySpriteSheetAnimation && input.WasKeyPressed(Slush::Input::V))
 			anim->PlayAnimation(*mySpriteSheetAnimation);
 	}
 }

--- a/Solution/ActionGame/Components/ProjectileShootingComponent.cpp
+++ b/Solution/ActionGame/Components/ProjectileShootingComponent.cpp
@@ -67,8 +67,16 @@ bool ProjectileShootingComponent::TryShoot(const Vector2f& aDirection)
 
 	Vector2f projPosition = myEntity.myPosition + aDirection * shootingData.myProjectileSpawnOffset;
 	Slush::Entity* projectile = myEntity.myEntityManager.CreateEntity(projPosition, *prefab);
-	projectile->GetComponent<Slush::PhysicsComponent>()->myObject->myVelocity = aDirection * shootingData.myProjectileSpeed;
-	projectile->GetComponent<Slush::SpriteComponent>()->GetSprite().SetRotation(FW_SignedAngle(aDirection));
+
+	if (Slush::PhysicsComponent* physics = projectile->GetComponent<Slush::PhysicsComponent>())
+		physics->myObject->myVelocity = aDirection * shootingData.myProjectileSpeed;
+	else
+		SLUSH_ERROR("Entity spawned by 'ProjectileShootingComponent::TryShoot' is missing a 'PhysicsComponent'");
+
+	if (Slush::SpriteComponent* sprite = projectile->GetComponent<Slush::SpriteComponent>())
+		sprite->GetSprite().SetRotation(FW_SignedAngle(aDirection));
+	else
+		SLUSH_ERROR("Entity spawned by 'ProjectileShootingComponent::TryShoot' is missing a 'SpriteComponent'");
 
 	return true;
 }

--- a/Solution/ActionGame/Components/StatsComponent.cpp
+++ b/Solution/ActionGame/Components/StatsComponent.cpp
@@ -136,6 +136,9 @@ bool StatsComponent::CanUpgradeAnyStat() const
 
 void StatsComponent::UpgradeStat(StatType aStat)
 {
+	if (!myUpgradeData)
+		return;
+
 	RuntimeStat& runtime = myRuntimeStats[aStat];
 	const StatsUpgradeData::StatData& upgradeData = myUpgradeData->myStatDatas[aStat];
 
@@ -144,6 +147,9 @@ void StatsComponent::UpgradeStat(StatType aStat)
 
 bool StatsComponent::CanUpgradeStat(StatType aStat) const
 {
+	if (!myUpgradeData)
+		return false;
+
 	const RuntimeStat& runtime = myRuntimeStats[aStat];
 	const StatsUpgradeData::StatData& upgradeData = myUpgradeData->myStatDatas[aStat];
 

--- a/Solution/ActionGame/Components/WeaponComponent.cpp
+++ b/Solution/ActionGame/Components/WeaponComponent.cpp
@@ -276,8 +276,11 @@ void Weapon::ShootProjectile(const Vector2f& aDirection)
 		projDamage->SetDamage(damage);
 	}
 
-	if (Slush::AnimationComponent* anim = myEntity.GetComponent<Slush::AnimationComponent>())
-		anim->PlayAnimation(*mySpriteSheetAnimation);
+	if (mySpriteSheetAnimation)
+	{
+		if (Slush::AnimationComponent* anim = myEntity.GetComponent<Slush::AnimationComponent>())
+			anim->PlayAnimation(*mySpriteSheetAnimation);
+	}
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Solution/ActionGame/Components/WeaponComponent.cpp
+++ b/Solution/ActionGame/Components/WeaponComponent.cpp
@@ -313,6 +313,7 @@ WeaponComponent::WeaponComponent(Slush::Entity& anEntity, const Slush::EntityPre
 {
 	Slush::AssetRegistry& assets = Slush::AssetRegistry::GetInstance();
 	WeaponData* startingWeapon = anEntityPrefab.GetComponentData<WeaponComponent>().myWeaponData.Get();
+	FW_ASSERT(startingWeapon, "WeaponComponent has no valid starting WeaponData - check EntityPrefab's WeaponComponent data");
 
 	myWeapons.Add(new Weapon(myEntity, *startingWeapon));
 

--- a/Solution/ActionGame/Components/WeaponComponent.cpp
+++ b/Solution/ActionGame/Components/WeaponComponent.cpp
@@ -265,8 +265,17 @@ void Weapon::ShootProjectile(const Vector2f& aDirection)
 		return;
 
 	Slush::Entity* projectile = myEntity.myEntityManager.CreateEntity(myEntity.myPosition + aDirection * 35.f, *prefab);
-	projectile->GetComponent<Slush::PhysicsComponent>()->myObject->myVelocity = aDirection * myRankData->myProjectileData.myBaseProjectileSpeed;
-	projectile->GetComponent<Slush::SpriteComponent>()->GetSprite().SetRotation(FW_SignedAngle(aDirection));
+
+	if (Slush::PhysicsComponent* physics = projectile->GetComponent<Slush::PhysicsComponent>())
+		physics->myObject->myVelocity = aDirection * myRankData->myProjectileData.myBaseProjectileSpeed;
+	else
+		SLUSH_ERROR("Entity spawned by 'Weapon::ShootProjectile' is missing a 'PhysicsComponent'");
+
+	if (Slush::SpriteComponent* sprite = projectile->GetComponent<Slush::SpriteComponent>())
+		sprite->GetSprite().SetRotation(FW_SignedAngle(aDirection));
+	else
+		SLUSH_ERROR("Entity spawned by 'Weapon::ShootProjectile' is missing a 'SpriteComponent'");
+
 	if (DamageDealerComponent* projDamage = projectile->GetComponent<DamageDealerComponent>())
 	{
 		int damage = myRankData->myBaseDamage;

--- a/Solution/ActionGame/Level/Level.cpp
+++ b/Solution/ActionGame/Level/Level.cpp
@@ -48,20 +48,28 @@ void Level::Update(Slush::StateStack& aStateStack)
 	ExperienceComponent* expComp = player->GetComponent<ExperienceComponent>();
 	WeaponComponent* weaponComp = player->GetComponent<WeaponComponent>();
 
+	if (!expComp)
+		SLUSH_ERROR("Entity with player role is missing an 'ExperienceComponent'");
+
+	if (!weaponComp)
+		SLUSH_ERROR("Entity with player role is missing a 'WeaponComponent'");
+
 	Slush::Engine& engine = Slush::Engine::GetInstance();
 	const Slush::Input& input = engine.GetInput();
 	if (input.WasKeyReleased(Slush::Input::E))
 	{
-		expComp->AddExperience(1);
+		if (expComp)
+			expComp->AddExperience(1);
 	}
 	else if (input.WasKeyReleased(Slush::Input::Q))
 	{
-		weaponComp->AddPendingUpgrade();
+		if (weaponComp)
+			weaponComp->AddPendingUpgrade();
 	}
 
-	if (expComp->NeedsLevelUp())
+	if (expComp && expComp->NeedsLevelUp())
 		aStateStack.PushSubState(new UpgradeStatsState(myPlayerHandle));
-	else if (weaponComp->HasPendingUpgrade())
+	else if (weaponComp && weaponComp->HasPendingUpgrade())
 		aStateStack.PushSubState(new UpgradeWeaponState(myPlayerHandle));
 	else
 		HandleEnemyWaves();

--- a/Solution/ActionGame/StateStack/PauseState.cpp
+++ b/Solution/ActionGame/StateStack/PauseState.cpp
@@ -39,6 +39,13 @@ PauseState::PauseState(Slush::EntityHandle aPlayerHandle, const CharacterInfo& a
 
 Slush::IGameState::GameStateResult PauseState::Update()
 {
+	Slush::Entity* player = myPlayerHandle.Get();
+	if (!player)
+	{
+		SLUSH_ERROR("PauseState lost its player entity");
+		return Slush::IGameState::POP_SUBSTATE;
+	}
+
 	Slush::UIBuilder uiBuilder;
 
 	uiBuilder.Start();
@@ -100,6 +107,11 @@ void PauseState::BuildStatsDisplay(Slush::UIBuilder& aUIBUilder)
 {
 	Slush::Entity* player = myPlayerHandle.Get();
 	StatsComponent* stats = player->GetComponent<StatsComponent>();
+	if (!stats)
+	{
+		SLUSH_ERROR("Entity with 'PauseState' player role is missing a 'StatsComponent'");
+		return;
+	}
 
 	const StatsUpgradeData* upgradeData = stats->GetUpgradeData();
 
@@ -141,6 +153,12 @@ void PauseState::BuildWeaponsDisplay(Slush::UIBuilder& aUIBUilder)
 {
 	Slush::Entity* player = myPlayerHandle.Get();
 	WeaponComponent* weaponComponent = player->GetComponent<WeaponComponent>();
+	if (!weaponComponent)
+	{
+		SLUSH_ERROR("Entity with 'PauseState' player role is missing a 'WeaponComponent'");
+		return;
+	}
+
 	const FW_GrowingArray<Weapon*>& weapons = weaponComponent->GetWeapons();
 
 	aUIBUilder.OpenElement(myUIBackgroundStyle).SetLayoutDirection(Slush::UIElementStyle::TOP_TO_BOTTOM);

--- a/Solution/ActionGame/StateStack/PauseState.cpp
+++ b/Solution/ActionGame/StateStack/PauseState.cpp
@@ -119,9 +119,12 @@ void PauseState::BuildStatsDisplay(Slush::UIBuilder& aUIBUilder)
 		style.SetOutlineThickness(-1.f);
 		style.EnableButtonInteraction(0xFF888888);
 
-		const StatsUpgradeData::StatData& statdata = upgradeData->myStatDatas[statType];
-		if (const Slush::Texture* iconTexture = statdata.myIconTexture.Get())
-			aUIBUilder.Image(iconTexture, { 45, 45 }, statdata.myIconTextureRect);
+		if (upgradeData)
+		{
+			const StatsUpgradeData::StatData& statdata = upgradeData->myStatDatas[statType];
+			if (const Slush::Texture* iconTexture = statdata.myIconTexture.Get())
+				aUIBUilder.Image(iconTexture, { 45, 45 }, statdata.myIconTextureRect);
+		}
 
 		FW_String upgradeValue;
 		upgradeValue += "+";

--- a/Solution/ActionGame/StateStack/UpgradeStatsState.cpp
+++ b/Solution/ActionGame/StateStack/UpgradeStatsState.cpp
@@ -98,16 +98,19 @@ Slush::IGameState::GameStateResult UpgradeStatsState::Update()
 		style.SetOutlineThickness(-1.f);
 		style.EnableButtonInteraction(0xFF888888);
 
-		const StatsUpgradeData::StatData& statdata = upgradeData->myStatDatas[myUpgradeOptions[i]];
-		if (const Slush::Texture* iconTexture = statdata.myIconTexture.Get())
-			uiBuilder.Image(iconTexture, { 45, 45 }, statdata.myIconTextureRect);
+		if (upgradeData)
+		{
+			const StatsUpgradeData::StatData& statdata = upgradeData->myStatDatas[myUpgradeOptions[i]];
+			if (const Slush::Texture* iconTexture = statdata.myIconTexture.Get())
+				uiBuilder.Image(iconTexture, { 45, 45 }, statdata.myIconTextureRect);
 
-		uiBuilder.Text(myUpgradeLabels[i].GetBuffer(), ActionGameGlobals::GetInstance().GetFont(), 25, 0xFFFFFFFF);
-		FW_String upgradeValue;
-		upgradeValue += "+";
-		upgradeValue += static_cast<int>(statdata.myIncreasePerUpgrade * 100);
-		upgradeValue += "%";
-		uiBuilder.Text(upgradeValue.GetBuffer(), ActionGameGlobals::GetInstance().GetFont(), 18, 0xFF44FF44);
+			uiBuilder.Text(myUpgradeLabels[i].GetBuffer(), ActionGameGlobals::GetInstance().GetFont(), 25, 0xFFFFFFFF);
+			FW_String upgradeValue;
+			upgradeValue += "+";
+			upgradeValue += static_cast<int>(statdata.myIncreasePerUpgrade * 100);
+			upgradeValue += "%";
+			uiBuilder.Text(upgradeValue.GetBuffer(), ActionGameGlobals::GetInstance().GetFont(), 18, 0xFF44FF44);
+		}
 
 		uiBuilder.CloseElement();
 	}

--- a/Solution/ActionGame/StateStack/UpgradeStatsState.cpp
+++ b/Solution/ActionGame/StateStack/UpgradeStatsState.cpp
@@ -34,6 +34,18 @@ UpgradeStatsState::UpgradeStatsState(Slush::EntityHandle aPlayerHandle)
 	ExperienceComponent* expComp = player->GetComponent<ExperienceComponent>();
 	StatsComponent* stats = player->GetComponent<StatsComponent>();
 
+	if (!expComp)
+	{
+		SLUSH_ERROR("Entity with 'UpgradeStatsState' player role is missing an 'ExperienceComponent'");
+		return;
+	}
+
+	if (!stats)
+	{
+		SLUSH_ERROR("Entity with 'UpgradeStatsState' player role is missing a 'StatsComponent'");
+		return;
+	}
+
 	FW_GrowingArray<StatType> potentialUpgrades;
 	potentialUpgrades.Add(StatType::COOLDOWN);
 	potentialUpgrades.Add(StatType::DAMAGE);
@@ -59,7 +71,18 @@ UpgradeStatsState::UpgradeStatsState(Slush::EntityHandle aPlayerHandle)
 Slush::IGameState::GameStateResult UpgradeStatsState::Update()
 {
 	Slush::Entity* player = myPlayerHandle.Get();
+	if (!player)
+	{
+		SLUSH_ERROR("UpgradeStatsState lost its player entity");
+		return Slush::IGameState::POP_SUBSTATE;
+	}
+
 	ExperienceComponent* expComp = player->GetComponent<ExperienceComponent>();
+	if (!expComp)
+	{
+		SLUSH_ERROR("Entity with 'UpgradeStatsState' player role is missing an 'ExperienceComponent'");
+		return Slush::IGameState::POP_SUBSTATE;
+	}
 
 	if (myUpgradeOptions.IsEmpty())
 	{
@@ -69,6 +92,11 @@ Slush::IGameState::GameStateResult UpgradeStatsState::Update()
 	}
 
 	StatsComponent* stats = player->GetComponent<StatsComponent>();
+	if (!stats)
+	{
+		SLUSH_ERROR("Entity with 'UpgradeStatsState' player role is missing a 'StatsComponent'");
+		return Slush::IGameState::POP_SUBSTATE;
+	}
 
 	const StatsUpgradeData* upgradeData = stats->GetUpgradeData();
 

--- a/Solution/ActionGame/StateStack/UpgradeWeaponState.cpp
+++ b/Solution/ActionGame/StateStack/UpgradeWeaponState.cpp
@@ -32,7 +32,18 @@ UpgradeWeaponState::UpgradeWeaponState(Slush::EntityHandle aPlayerHandle)
 Slush::IGameState::GameStateResult UpgradeWeaponState::Update()
 {
 	Slush::Entity* player = myPlayerHandle.Get();
+	if (!player)
+	{
+		SLUSH_ERROR("UpgradeWeaponState lost its player entity");
+		return Slush::IGameState::POP_SUBSTATE;
+	}
+
 	WeaponComponent* weaponComponent = player->GetComponent<WeaponComponent>();
+	if (!weaponComponent)
+	{
+		SLUSH_ERROR("Entity with 'UpgradeWeaponState' player role is missing a 'WeaponComponent'");
+		return Slush::IGameState::POP_SUBSTATE;
+	}
 
 	if (!weaponComponent->HasPendingUpgrade())
 		return Slush::IGameState::POP_SUBSTATE;


### PR DESCRIPTION
Guards several previously-unguarded pointer derefs in ActionGame components (cached AssetRegistry::GetAsset<T>() pointers, AssetReference<T> derefs, GetComponent<T>() lookups, and EntityHandle::Get() results) that could crash if a prefab is missing expected data or an entity/component goes away mid-session. Landed as three phases per the issue: mechanical asset-pointer guards, AssetReference<T>/WeaponData invariant guard, and the per-frame gameplay-loop guards (verified live via headless SkipStartScreen repro).

Closes #32