### PR TITLE
Restructure the main loop into explicit frame phases; fix update/render ordering

### DIFF
--- a/Solution/Engine/Core/Engine.cpp
+++ b/Solution/Engine/Core/Engine.cpp
@@ -148,6 +148,13 @@ namespace Slush
 			myWindow->GetRenderer().RenderFade();
 			myWindow->GetRenderer().FinalizeOffscreenBuffer();
 
+			myWindow->BuildEditorChrome();
+
+			// The editor path composites via GameViewDockable -> RenderOffscreenBufferToImGUI() -> ImGui::Image
+			// instead, since the game view there is an ImGui-laid-out dockable panel.
+			if (!myWindow->IsEditorUIVisible())
+				myWindow->Composite();
+
 			myWindow->Present();
 		}
 

--- a/Solution/Engine/Core/Engine.cpp
+++ b/Solution/Engine/Core/Engine.cpp
@@ -141,10 +141,12 @@ namespace Slush
 
 			anApp.Render();
 			myWindow->UpdateAppLayout();
+			myWindow->GetRenderer().UpdateFade();
 			myWindow->RenderAppLayout();
 
 			myWindow->GetRenderer().ProcessRenderQueue();
 			myWindow->GetRenderer().RenderFade();
+			myWindow->GetRenderer().FinalizeOffscreenBuffer();
 
 			myWindow->Present();
 		}

--- a/Solution/Engine/Core/Engine.cpp
+++ b/Solution/Engine/Core/Engine.cpp
@@ -110,13 +110,6 @@ namespace Slush
 		{
 			myWindow->PumpEvents();
 
-			if (myInput->WasKeyPressed(Slush::Input::HYPHEN))
-				myWindow->ToggleEditorUI();
-
-			myWindow->UpdatePendingClose();
-
-			ImGui::SFML::Update(*myWindow->GetRenderWindow(), Time::GetDelta());
-
 			Time::Update();
 			myLogger->Update();
 
@@ -134,14 +127,21 @@ namespace Slush
 				myInput->RemapMousePosition(myWindow->GetWindowRect(), myWindow->GetGameViewRect());
 			}
 
+			if (myInput->WasKeyPressed(Slush::Input::_F10))
+				myWindow->RequestScreenshot();
+
+			if (myInput->WasKeyPressed(Slush::Input::HYPHEN))
+				myWindow->ToggleEditorUI();
+
+			myWindow->UpdatePendingClose();
+
+			ImGui::SFML::Update(*myWindow->GetRenderWindow(), Time::GetDelta());
+
 			anApp.Update();
 
 			anApp.Render();
 			myWindow->RenderAppLayout();
 			myWindow->UpdateAppLayout();
-
-			if (myInput->WasKeyPressed(Slush::Input::_F10))
-				myWindow->RequestScreenshot();
 
 			myWindow->GetRenderer().ProcessRenderQueue();
 			myWindow->GetRenderer().RenderFade();

--- a/Solution/Engine/Core/Engine.cpp
+++ b/Solution/Engine/Core/Engine.cpp
@@ -106,8 +106,17 @@ namespace Slush
 	{
 		anApp.Initialize();
 
-		while (myWindow->PumpEvents())
+		while (myWindow->IsOpen())
 		{
+			myWindow->PumpEvents();
+
+			if (myInput->WasKeyPressed(Slush::Input::HYPHEN))
+				myWindow->ToggleEditorUI();
+
+			myWindow->UpdatePendingClose();
+
+			ImGui::SFML::Update(*myWindow->GetRenderWindow(), Time::GetDelta());
+
 			Time::Update();
 			myLogger->Update();
 

--- a/Solution/Engine/Core/Engine.cpp
+++ b/Solution/Engine/Core/Engine.cpp
@@ -140,8 +140,8 @@ namespace Slush
 			anApp.Update();
 
 			anApp.Render();
-			myWindow->RenderAppLayout();
 			myWindow->UpdateAppLayout();
+			myWindow->RenderAppLayout();
 
 			myWindow->GetRenderer().ProcessRenderQueue();
 			myWindow->GetRenderer().RenderFade();

--- a/Solution/Engine/Core/Engine.cpp
+++ b/Solution/Engine/Core/Engine.cpp
@@ -102,6 +102,74 @@ namespace Slush
 		FW_SAFE_DELETE(myLogger);
 	}
 
+	void Engine::BeginFrame()
+	{
+		Time::Update();
+		myLogger->Update();
+	}
+
+	void Engine::UpdateInput()
+	{
+		ImGuiIO& imguiIO = ImGui::GetIO();
+
+		if (!imguiIO.WantCaptureKeyboard)
+			myInput->UpdateKeyboard();
+
+		if (CommandLineArgs::GetInstance().HasFlag("-usedebuginput"))
+			myInput->PollDebugInputFile(imguiIO.WantCaptureKeyboard);
+
+		if (!imguiIO.WantCaptureMouse || myByPassImGUIInputRestriction)
+		{
+			myInput->UpdateMouse(*myWindow->GetRenderWindow());
+			myInput->RemapMousePosition(myWindow->GetWindowRect(), myWindow->GetGameViewRect());
+		}
+
+		if (myInput->WasKeyPressed(Slush::Input::_F10))
+			myWindow->RequestScreenshot();
+
+		if (myInput->WasKeyPressed(Slush::Input::HYPHEN))
+			myWindow->ToggleEditorUI();
+
+		myWindow->UpdatePendingClose();
+	}
+
+	void Engine::BeginImGuiFrame()
+	{
+		ImGui::SFML::Update(*myWindow->GetRenderWindow(), Time::GetDelta());
+	}
+
+	void Engine::UpdateSimulation(IApp& anApp)
+	{
+		anApp.Update();
+		myWindow->UpdateAppLayout();
+		myWindow->GetRenderer().UpdateFade();
+	}
+
+	void Engine::RenderFrame(IApp& anApp)
+	{
+		anApp.Render();
+		myWindow->RenderAppLayout();
+
+		myWindow->GetRenderer().ProcessRenderQueue();
+		myWindow->GetRenderer().RenderFade();
+		myWindow->GetRenderer().FinalizeOffscreenBuffer();
+	}
+
+	void Engine::BuildEditorUI()
+	{
+		myWindow->BuildEditorChrome();
+	}
+
+	void Engine::CompositeAndPresent()
+	{
+		// The editor path composites via GameViewDockable -> RenderOffscreenBufferToImGUI() -> ImGui::Image
+		// instead, since the game view there is an ImGui-laid-out dockable panel.
+		if (!myWindow->IsEditorUIVisible())
+			myWindow->Composite();
+
+		myWindow->Present();
+	}
+
 	void Engine::Run(IApp& anApp)
 	{
 		anApp.Initialize();
@@ -109,53 +177,13 @@ namespace Slush
 		while (myWindow->IsOpen())
 		{
 			myWindow->PumpEvents();
-
-			Time::Update();
-			myLogger->Update();
-
-			ImGuiIO& imguiIO = ImGui::GetIO();
-
-			if(!imguiIO.WantCaptureKeyboard)
-				myInput->UpdateKeyboard();
-
-			if (CommandLineArgs::GetInstance().HasFlag("-usedebuginput"))
-				myInput->PollDebugInputFile(imguiIO.WantCaptureKeyboard);
-
-			if (!imguiIO.WantCaptureMouse || myByPassImGUIInputRestriction)
-			{
-				myInput->UpdateMouse(*myWindow->GetRenderWindow());
-				myInput->RemapMousePosition(myWindow->GetWindowRect(), myWindow->GetGameViewRect());
-			}
-
-			if (myInput->WasKeyPressed(Slush::Input::_F10))
-				myWindow->RequestScreenshot();
-
-			if (myInput->WasKeyPressed(Slush::Input::HYPHEN))
-				myWindow->ToggleEditorUI();
-
-			myWindow->UpdatePendingClose();
-
-			ImGui::SFML::Update(*myWindow->GetRenderWindow(), Time::GetDelta());
-
-			anApp.Update();
-
-			anApp.Render();
-			myWindow->UpdateAppLayout();
-			myWindow->GetRenderer().UpdateFade();
-			myWindow->RenderAppLayout();
-
-			myWindow->GetRenderer().ProcessRenderQueue();
-			myWindow->GetRenderer().RenderFade();
-			myWindow->GetRenderer().FinalizeOffscreenBuffer();
-
-			myWindow->BuildEditorChrome();
-
-			// The editor path composites via GameViewDockable -> RenderOffscreenBufferToImGUI() -> ImGui::Image
-			// instead, since the game view there is an ImGui-laid-out dockable panel.
-			if (!myWindow->IsEditorUIVisible())
-				myWindow->Composite();
-
-			myWindow->Present();
+			BeginFrame();
+			UpdateInput();
+			BeginImGuiFrame();
+			UpdateSimulation(anApp);
+			RenderFrame(anApp);
+			BuildEditorUI();
+			CompositeAndPresent();
 		}
 
 		anApp.Shutdown();

--- a/Solution/Engine/Core/Engine.h
+++ b/Solution/Engine/Core/Engine.h
@@ -32,6 +32,14 @@ namespace Slush
 		~Engine() {};
 		static Engine* ourInstance;
 
+		void BeginFrame();
+		void UpdateInput();
+		void BeginImGuiFrame();
+		void UpdateSimulation(IApp& anApp);
+		void RenderFrame(IApp& anApp);
+		void BuildEditorUI();
+		void CompositeAndPresent();
+
 		Window* myWindow = nullptr;
 		Input* myInput = nullptr;
 		Logger* myLogger = nullptr;

--- a/Solution/Engine/Core/IApp.h
+++ b/Solution/Engine/Core/IApp.h
@@ -9,6 +9,10 @@ namespace Slush
 		virtual void Shutdown() {};
 
 		virtual void Update() {};
+
+		// Not dead despite ActionGame's override being empty - BossMonster (main.cpp) and TopDownGame
+		// (main.cpp) have no game-rendering IAppLayout and use this as their only render entry point,
+		// wrapping StartOffscreenBuffer()/EndOffscreenBuffer() around their draws.
 		virtual void Render() {};
 	};
 }

--- a/Solution/Engine/Graphics/Renderer.cpp
+++ b/Solution/Engine/Graphics/Renderer.cpp
@@ -295,7 +295,7 @@ namespace Slush
 		myFadeData.myTotalTime = aDuration;
 	}
 
-	void Renderer::RenderFade()
+	void Renderer::UpdateFade()
 	{
 		if (myFadeData.myIsFading)
 		{
@@ -303,7 +303,10 @@ namespace Slush
 			if (myFadeData.myRemainingTime <= 0.f)
 				myFadeData.myIsFading = false;
 		}
+	}
 
+	void Renderer::RenderFade()
+	{
 		if (myFadeData.myIsFading)
 		{
 			float alpha = FW_Max(0.f, myFadeData.myRemainingTime / myFadeData.myTotalTime);
@@ -313,7 +316,10 @@ namespace Slush
 			rect.setFillColor(SFMLHelpers::GetColor(FW_Float_To_ARGB(alpha, 1.f, 1.f, 1.f)));
 			myOffscreenBuffer->draw(rect);
 		}
+	}
 
+	void Renderer::FinalizeOffscreenBuffer()
+	{
 		myOffscreenBuffer->display();
 
 		if (!myFadeData.myIsFading)

--- a/Solution/Engine/Graphics/Renderer.h
+++ b/Solution/Engine/Graphics/Renderer.h
@@ -40,7 +40,9 @@ namespace Slush
 		void RenderText(const Font& aFont, const FW_String& aString, const Vector2f& aPosition, int aCharacterSize, int aColor);
 
 		void StartFade(float aDuration);
+		void UpdateFade();
 		void RenderFade();
+		void FinalizeOffscreenBuffer();
 
 		void ProcessRenderQueue();
 

--- a/Solution/Engine/Graphics/Window.cpp
+++ b/Solution/Engine/Graphics/Window.cpp
@@ -3,9 +3,6 @@
 #include "Graphics/Window.h"
 #include "Graphics/Renderer.h"
 #include "Core/Log.h"
-#include "Core/Engine.h"
-#include "Core/Input.h"
-#include "Core/Time.h"
 #include "Core/Dockables/Dockable.h"
 #include "Core/Dockables/IAppLayout.h"
 
@@ -57,11 +54,8 @@ namespace Slush
 		myRenderWindow->setVisible(false);
 	}
 
-	bool Window::PumpEvents()
+	void Window::PumpEvents()
 	{
-		if (!myShouldBeOpen)
-			return false;
-
 		while (const std::optional event = myRenderWindow->pollEvent())
 		{
 			ImGui::SFML::ProcessEvent(*myRenderWindow, *event);
@@ -77,15 +71,6 @@ namespace Slush
 				myRenderWindow->setView(sf::View(visibleArea));
 			}
 		}
-
-		if (Slush::Engine::GetInstance().GetInput().WasKeyPressed(Slush::Input::HYPHEN))
-			ToggleEditorUI();
-
-		UpdatePendingClose();
-
-		ImGui::SFML::Update(*myRenderWindow, Time::GetDelta());
-
-		return true;
 	}
 
 	void Window::RenderOffscreenBufferToImGUI()

--- a/Solution/Engine/Graphics/Window.cpp
+++ b/Solution/Engine/Graphics/Window.cpp
@@ -81,14 +81,9 @@ namespace Slush
 		if (Slush::Engine::GetInstance().GetInput().WasKeyPressed(Slush::Input::HYPHEN))
 			ToggleEditorUI();
 
-		// Must run before the myShowEditorUI check below: this can force the editor back on for a pending
-		// close, and that has to take effect in time to begin this frame's ImGui frame - otherwise Present()
-		// still sees myShowEditorUI true (set here) but ImGui::SFML::Update() (ImGui::NewFrame()) never
-		// ran this frame, so its ImGui::Begin() calls assert.
 		UpdatePendingClose();
 
-		if (myShowEditorUI)
-			ImGui::SFML::Update(*myRenderWindow, Time::GetDelta());
+		ImGui::SFML::Update(*myRenderWindow, Time::GetDelta());
 
 		return true;
 	}
@@ -142,8 +137,6 @@ namespace Slush
 
 			if (myAppLayout)
 				myAppLayout->BuildUI();
-
-			ImGui::SFML::Render(*myRenderWindow);
 		}
 		else
 		{
@@ -160,6 +153,8 @@ namespace Slush
 
 			myRenderWindow->draw(rect);
 		}
+
+		ImGui::SFML::Render(*myRenderWindow);
 
 		myRenderWindow->display();
 
@@ -230,12 +225,8 @@ namespace Slush
 			return;
 		}
 
-		// PumpEvents() skips ImGui::SFML::Update() while the editor is hidden, so no ImGui frame is begun
-		// and the close-confirmation modal (built in the editor-only BuildUI() half) has nothing to draw
-		// into and no way to take input - force the editor on so a quit initiated from the game view still
-		// gets to draw and take input on the confirmation popup. Must happen before PumpEvents()'s own
-		// myShowEditorUI check (that's why this is called from there, not from Present()) so the forced
-		// value takes effect in time for this same frame's ImGui::SFML::Update() to actually run.
+		// The close-confirmation modal is built in the editor-only BuildUI() half, so the editor must be
+		// visible for the user to see and click it.
 		myShowEditorUI = true;
 
 		switch (myAppLayout->RequestClose())

--- a/Solution/Engine/Graphics/Window.cpp
+++ b/Solution/Engine/Graphics/Window.cpp
@@ -90,55 +90,59 @@ namespace Slush
 		ImGui::Image(textureID, { myGameViewRect.myExtents.x, myGameViewRect.myExtents.y }, { 0, 1 }, { 1, 0 });
 	}
 
-	void Window::Present()
+	void Window::BuildEditorChrome()
 	{
-		if (myShowEditorUI)
+		if (!myShowEditorUI)
+			return;
+
+		if (ImGui::BeginMainMenuBar())
 		{
-			if (ImGui::BeginMainMenuBar())
+			if (myAppLayout)
+				ImGui::Text("[ %s ]", myAppLayout->GetName().GetBuffer());
+
+			if (ImGui::BeginMenu("Layouts"))
 			{
-				if (myAppLayout)
-					ImGui::Text("[ %s ]", myAppLayout->GetName().GetBuffer());
-
-				if (ImGui::BeginMenu("Layouts"))
-				{
-					ImGui::Selectable("Game");
-					ImGui::Selectable("Entity");
-					ImGui::EndMenu();
-				}
-
-				if (ImGui::BeginMenu("ImGUI"))
-				{
-					ImGui::Checkbox("Show Demo", &myDisplayImGUIDemo);
-					ImGui::EndMenu();
-				}
-
-				ImGui::EndMainMenuBar();
+				ImGui::Selectable("Game");
+				ImGui::Selectable("Entity");
+				ImGui::EndMenu();
 			}
 
-			ImGui::DockSpaceOverViewport();
+			if (ImGui::BeginMenu("ImGUI"))
+			{
+				ImGui::Checkbox("Show Demo", &myDisplayImGUIDemo);
+				ImGui::EndMenu();
+			}
 
-			if (myDisplayImGUIDemo)
-				ImGui::ShowDemoWindow(&myDisplayImGUIDemo);
-
-			if (myAppLayout)
-				myAppLayout->BuildUI();
-		}
-		else
-		{
-			myGameViewRect = myWindowRect;
-
-			// If we're not in 'ShowEditorUI'-mode, then we need to render the OffScreenBuffer that contains the Gamerender
-			// to the screen using a rectshape.
-			// While in 'ShowEditorUI'-mode this will instead happen through the 'GameViewDockable'.
-			Vector2f adjustedSize = GetSizeThatRespectsAspectRatio(static_cast<int>(myWindowRect.myExtents.x), static_cast<int>(myWindowRect.myExtents.y));
-
-			sf::RectangleShape rect;
-			rect.setTexture(&myRenderer->GetOffscreenBuffer()->getTexture());
-			rect.setSize({ adjustedSize.x, adjustedSize.y });
-
-			myRenderWindow->draw(rect);
+			ImGui::EndMainMenuBar();
 		}
 
+		ImGui::DockSpaceOverViewport();
+
+		if (myDisplayImGUIDemo)
+			ImGui::ShowDemoWindow(&myDisplayImGUIDemo);
+
+		if (myAppLayout)
+			myAppLayout->BuildUI();
+	}
+
+	void Window::Composite()
+	{
+		myGameViewRect = myWindowRect;
+
+		// If we're not in 'ShowEditorUI'-mode, then we need to render the OffScreenBuffer that contains the Gamerender
+		// to the screen using a rectshape.
+		// While in 'ShowEditorUI'-mode this will instead happen through the 'GameViewDockable'.
+		Vector2f adjustedSize = GetSizeThatRespectsAspectRatio(static_cast<int>(myWindowRect.myExtents.x), static_cast<int>(myWindowRect.myExtents.y));
+
+		sf::RectangleShape rect;
+		rect.setTexture(&myRenderer->GetOffscreenBuffer()->getTexture());
+		rect.setSize({ adjustedSize.x, adjustedSize.y });
+
+		myRenderWindow->draw(rect);
+	}
+
+	void Window::Present()
+	{
 		ImGui::SFML::Render(*myRenderWindow);
 
 		myRenderWindow->display();

--- a/Solution/Engine/Graphics/Window.h
+++ b/Solution/Engine/Graphics/Window.h
@@ -22,6 +22,8 @@ namespace Slush
 
 		void RequestScreenshot() { myScreenshotRequested = true; }
 
+		void BuildEditorChrome();
+		void Composite();
 		void Present();
 
 		// Single chokepoint for every way of quitting - resolves any unsaved changes (via the owning
@@ -31,6 +33,7 @@ namespace Slush
 		void Hide();
 
 		void ToggleEditorUI() { myShowEditorUI = !myShowEditorUI; }
+		bool IsEditorUIVisible() const { return myShowEditorUI; }
 
 		void SetAppLayout(IAppLayout* aLayout);
 

--- a/Solution/Engine/Graphics/Window.h
+++ b/Solution/Engine/Graphics/Window.h
@@ -16,7 +16,8 @@ namespace Slush
 		Window(unsigned int aWidth, unsigned int aHeight);
 		~Window();
 
-		bool PumpEvents();
+		bool IsOpen() const { return myShouldBeOpen; }
+		void PumpEvents();
 		void RenderOffscreenBufferToImGUI();
 
 		void RequestScreenshot() { myScreenshotRequested = true; }
@@ -36,6 +37,9 @@ namespace Slush
 		void UpdateAppLayout();
 		void RenderAppLayout();
 
+		// Called every frame (from Engine::Run()) while a close is pending, until it's resolved or cancelled.
+		void UpdatePendingClose();
+
 		sf::RenderWindow* GetRenderWindow() const { return myRenderWindow; }
 		Renderer& GetRenderer() const { return *myRenderer; }
 
@@ -47,9 +51,6 @@ namespace Slush
 		void LoadAppLayoutConfig();
 
 		void SaveScreenshot();
-
-		// Called every frame (from Present()) while a close is pending, until it's resolved or cancelled.
-		void UpdatePendingClose();
 
 		// Single point where myShouldBeOpen actually flips false, so there's always a log line marking
 		// a graceful shutdown - useful for telling it apart from a crash or a forcibly-killed process.

--- a/Solution/Engine/StateStack/IGameState.h
+++ b/Solution/Engine/StateStack/IGameState.h
@@ -23,6 +23,10 @@ namespace Slush
 
 		virtual GameStateResult Update() = 0;
 		virtual void Render() {};
+
+		// Lets a lower state keep rendering while it's not the one being updated - e.g. a paused game
+		// staying visible behind the pause menu. See StateStack::Update()/Render() for why this 1:N
+		// relationship means the Update/Render split can't be merged.
 		virtual bool AllowPassThroughRender() { return false; }
 
 		StateStack* myStateStack = nullptr;

--- a/Solution/Engine/StateStack/StateStack.h
+++ b/Solution/Engine/StateStack/StateStack.h
@@ -10,6 +10,13 @@ namespace Slush
 		void PushMainState(IGameState* aState);
 		void PushSubState(IGameState* aState);
 
+		// This split cannot be merged: Update() advances only the top state, while Render() recurses
+		// down through AllowPassThroughRender() and renders bottom-to-top - a 1:N relationship (one
+		// state updates, several may render) that is how a paused game stays visible behind a menu.
+		// Unrelated to immediate-mode draw ordering, so the RenderQueue landing (#11) didn't dissolve
+		// it. Because the pass-through recursion submits bottom-to-top in a single pass, submission
+		// order already equals correct back-to-front draw order - no z-index/layer concept is needed
+		// in the render queue to support it.
 		void Update();
 		void Render();
 


### PR DESCRIPTION
## Description

Restructure `Engine::Run()`'s main loop into explicit, named frame phases, fixing two ordering defects (editor-toggle reading stale input, simulation lagging render by a frame) along the way.

Closes #12

## Agent End-of-run Summary

All 8 phases completed and committed individually:

1. Make the ImGui frame lifecycle unconditional (`1ba7669`)
2. Split `Window::PumpEvents()` into `IsOpen()` + `PumpEvents()` (`29948df`)
3. Move input refresh ahead of the editor-toggle read (`3ec9279`)
4. Move simulation ahead of render (`f4e5780`)
5. Split `Renderer::RenderFade()` three ways (`89537f0`)
6. Split `Window::Present()` into `BuildEditorChrome()` + `Composite()` + `Present()` (`56a3789`)
7. Introduce `Engine` frame-phase helpers and finalize `Run()` (`4292a81`)
8. Document why the Update/Render split exists (`22751bb`)

Notable issues hit during the autonomous run:

- **BossMonster consistently fails to launch headlessly** on a pre-existing, unrelated issue: `Workbed/BossMonster/Data/` is missing `NotoSans.ttf` (only `ActionGame`'s `Data/` folder has it), so it asserts during font loading in `Engine::Initialize()` — before `Engine::Run()` is ever reached. This predates this branch and none of the 8 phases touch font loading, so it was left alone; BossMonster's `IApp::Render()` path (the third of the three compositing/render paths phases 5-6 touch) could not be exercised live in this run as a result. ActionGame and TopDownGame were both exercised live for every phase that touched rendering/compositing.
- **Phase 7 surfaced a genuine tension** between Phase 4's narrowly-scoped text ("only swap `RenderAppLayout()`/`UpdateAppLayout()`") and Phase 7's literal grouping requirement (`RenderFrame()` needed `anApp.Render()` to be contiguous with `RenderAppLayout()`/`ProcessRenderQueue()`/etc., which meant moving it from directly-after-`anApp.Update()`, where Phase 4 left it). The run was paused and the user was asked to choose: move `anApp.Render()` as part of Phase 7, or keep it in place and write non-contiguous helpers deviating from the issue's literal pseudocode. The user chose to move it as part of Phase 7 — documented in that phase's commit message, with the move verified behavior-neutral for all three games (none of their `anApp.Render()` overrides depend on `IAppLayout`/`Renderer::UpdateFade()` state).

Automatic review pass: a code-reviewer agent examined the full diff against every phase's stated requirements (matching phase descriptions to actual code, cross-phase consistency, anything the issue explicitly forbade, dead code/stale comments). **No correctness problems found — empty findings list.**

Please review the committed changes in this PR before deciding whether the issue is actually finished or needs more work.

## Agent Verifications

- **Phase 1**: All three games build (x86 Debug). TopDownGame (permanently editor-hidden) launched headlessly and rendered a live frame via `F10` screenshot with no assert. ActionGame toggled the editor UI both directions (`HYPHEN` twice with `F10` screenshots either side) under `-hidewindow -usedebuginput`, confirming no `ImGui::Begin()`-with-no-`NewFrame()` assert in either direction.
- **Phase 2**: Build succeeded. ActionGame with `SkipStartScreen` reached live gameplay (`F10` screenshot showed player/enemies/level). Clean exit under `-hidewindow` verified via TopDownGame's `ESC`-bound `Window::Close()` — process self-terminated with the expected `"[Window] Closing gracefully (no unsaved changes)"` log line, exercising `UpdatePendingClose()` from its new call site in `Engine::Run()`.
- **Phase 3**: Build succeeded. Injected `HYPHEN` and `F10` on consecutive lines (same debug-input-file frame) in ActionGame; the resulting screenshot showed the editor UI already toggled off, proving same-frame responsiveness (previously the toggle would have lagged a frame under the old ordering). BossMonster launch attempted but hit the pre-existing font-load issue described above (unrelated).
- **Phase 4**: Build succeeded. ActionGame with `SkipStartScreen` showed live gameplay via `F10`. Injected `ESC` to open the pause menu and captured a screenshot showing the "Paused!" overlay correctly composited over the still-visible game behind it (the `AllowPassThroughRender()` path), confirming the `UpdateAppLayout()`/`RenderAppLayout()` swap didn't break pass-through rendering.
- **Phase 5**: Build succeeded. ActionGame `SkipStartScreen` `F10` screenshot showed a live, non-black/non-frozen level, confirming `FinalizeOffscreenBuffer()` finalizes correctly from its new call site. TopDownGame's non-editor composite path also confirmed rendering correctly.
- **Phase 6**: Build succeeded. ActionGame's editor-mode dockable Game View rendered live content via `BuildEditorChrome()`. `HYPHEN` toggled cleanly in both directions between the `Composite()` path and the editor `ImGui::Image` path (screenshots confirmed both). TopDownGame's non-editor `Composite()` path also confirmed rendering correctly.
- **Phase 7**: Build succeeded. Re-verified ActionGame `SkipStartScreen` gameplay + `F10` screenshot, the `HYPHEN` toggle, and TopDownGame's clean `ESC`-triggered exit (self-terminated with the graceful-close log line) all still work under the fully regrouped `Engine::Run()`.
- **Phase 8**: Comment-only change; build succeeded, no runtime verification needed.
