### PR TITLE
Ground-path computation

### DIFF
--- a/Solution/TopDownGame/Navmesh.cpp
+++ b/Solution/TopDownGame/Navmesh.cpp
@@ -309,6 +309,7 @@ bool Navmesh::FindTrianglePath(const Vector2f& aStart, Triangle* aStartTriangle,
 
 bool Navmesh::BuildEdgeCenterPath(const Vector2f& aStart, const Vector2f& aGoal, const PathCorridor& aCorridor, FW_GrowingArray<Vector2f>& outWaypoints) const
 {
+	outWaypoints.RemoveAll();
 	outWaypoints.Add(aStart);
 
 	for (const Portal& portal : aCorridor.myPortals)
@@ -328,6 +329,8 @@ namespace
 
 bool Navmesh::StringPull(const Vector2f& aStart, const Vector2f& aGoal, const PathCorridor& aCorridor, FW_GrowingArray<Vector2f>& outWaypoints) const
 {
+	outWaypoints.RemoveAll();
+
 	if (aCorridor.myPortals.IsEmpty())
 	{
 		outWaypoints.Add(aStart);
@@ -421,12 +424,17 @@ bool Navmesh::FindPath(const Vector2f& aStart, const Vector2f& aGoal, FW_Growing
 	if (startTriangle == nullptr || goalTriangle == nullptr)
 		return false;
 
+	PathCorridor foundCorridor;
 	if (startTriangle != goalTriangle)
 	{
-		if (!FindTrianglePath(aStart, startTriangle, goalTriangle, outCorridor))
+		if (!FindTrianglePath(aStart, startTriangle, goalTriangle, foundCorridor))
 			return false;
 	}
 
+	// Build into a local corridor and only hand it to the caller once the search has
+	// actually succeeded, so a reused outCorridor is replaced rather than appended to
+	// (guaranteeing the zero-portal same-triangle case) and stays untouched on failure.
+	outCorridor = foundCorridor;
 	return StringPull(aStart, aGoal, outCorridor, outWaypoints);
 }
 

--- a/Solution/TopDownGame/Navmesh.cpp
+++ b/Solution/TopDownGame/Navmesh.cpp
@@ -140,6 +140,189 @@ void Navmesh::Render()
 		renderer.RenderLine(myCutPositions.GetLast(), mousePos, 0xFF000000);
 }
 
+Navmesh::Triangle* Navmesh::FindTriangleContaining(const Vector2f& aPosition) const
+{
+	for (Triangle* triangle : myTriangles)
+	{
+		if (triangle->PointInside(aPosition))
+			return triangle;
+	}
+
+	return nullptr;
+}
+
+bool Navmesh::FindTrianglePath(Triangle* aStartTriangle, Triangle* aGoalTriangle, PathCorridor& outCorridor) const
+{
+	FW_GrowingArray<AStarNode> nodes;
+
+	AStarNode& startNode = nodes.Add();
+	startNode.myTriangle = aStartTriangle;
+	startNode.myGCost = 0.f;
+	startNode.myFCost = Length(aStartTriangle->GetCenterPosition() - aGoalTriangle->GetCenterPosition());
+
+	while (true)
+	{
+		int bestIndex = -1;
+		float bestFCost = 0.f;
+		for (int i = 0; i < nodes.Count(); ++i)
+		{
+			if (nodes[i].myIsClosed)
+				continue;
+
+			if (bestIndex == -1 || nodes[i].myFCost < bestFCost)
+			{
+				bestIndex = i;
+				bestFCost = nodes[i].myFCost;
+			}
+		}
+
+		if (bestIndex == -1)
+			return false;
+
+		nodes[bestIndex].myIsClosed = true;
+
+		if (nodes[bestIndex].myTriangle == aGoalTriangle)
+		{
+			FW_GrowingArray<Edge*> reversedEdges;
+			int index = bestIndex;
+			while (nodes[index].myParentIndex != -1)
+			{
+				reversedEdges.Add(nodes[index].myEdgeFromParent);
+				index = nodes[index].myParentIndex;
+			}
+
+			Vertex* prevLeft = nullptr;
+			Vertex* prevRight = nullptr;
+			for (int i = reversedEdges.Count() - 1; i >= 0; --i)
+			{
+				Edge* edge = reversedEdges[i];
+				Vertex* v0 = edge->myVertices[0];
+				Vertex* v1 = edge->myVertices[1];
+
+				Vertex* left = nullptr;
+				Vertex* right = nullptr;
+
+				if (prevLeft == nullptr && prevRight == nullptr)
+				{
+					left = v0;
+					right = v1;
+				}
+				else if (v0 == prevLeft)
+				{
+					left = v0;
+					right = v1;
+				}
+				else if (v0 == prevRight)
+				{
+					right = v0;
+					left = v1;
+				}
+				else if (v1 == prevLeft)
+				{
+					left = v1;
+					right = v0;
+				}
+				else if (v1 == prevRight)
+				{
+					right = v1;
+					left = v0;
+				}
+				else
+				{
+					FW_ASSERT_ALWAYS("Expected consecutive portal edges to share a vertex");
+					left = v0;
+					right = v1;
+				}
+
+				Portal& portal = outCorridor.myPortals.Add();
+				portal.myLeft = left->myPos;
+				portal.myRight = right->myPos;
+
+				prevLeft = left;
+				prevRight = right;
+			}
+
+			return true;
+		}
+
+		Triangle* currentTriangle = nodes[bestIndex].myTriangle;
+		Vector2f currentCenter = currentTriangle->GetCenterPosition();
+		float currentGCost = nodes[bestIndex].myGCost;
+
+		for (int e = 0; e < 3; ++e)
+		{
+			Edge* edge = currentTriangle->myEdges[e];
+
+			for (int t = 0; t < 2; ++t)
+			{
+				Triangle* neighbor = edge->myTriangles[t];
+				if (neighbor == nullptr || neighbor == currentTriangle)
+					continue;
+
+				float tentativeGCost = currentGCost + Length(neighbor->GetCenterPosition() - currentCenter);
+
+				int existingIndex = -1;
+				for (int i = 0; i < nodes.Count(); ++i)
+				{
+					if (nodes[i].myTriangle == neighbor)
+					{
+						existingIndex = i;
+						break;
+					}
+				}
+
+				if (existingIndex != -1)
+				{
+					if (tentativeGCost >= nodes[existingIndex].myGCost)
+						continue;
+
+					nodes[existingIndex].myGCost = tentativeGCost;
+					nodes[existingIndex].myFCost = tentativeGCost + Length(neighbor->GetCenterPosition() - aGoalTriangle->GetCenterPosition());
+					nodes[existingIndex].myParentIndex = bestIndex;
+					nodes[existingIndex].myEdgeFromParent = edge;
+					nodes[existingIndex].myIsClosed = false;
+				}
+				else
+				{
+					AStarNode& newNode = nodes.Add();
+					newNode.myTriangle = neighbor;
+					newNode.myGCost = tentativeGCost;
+					newNode.myFCost = tentativeGCost + Length(neighbor->GetCenterPosition() - aGoalTriangle->GetCenterPosition());
+					newNode.myParentIndex = bestIndex;
+					newNode.myEdgeFromParent = edge;
+				}
+			}
+		}
+	}
+}
+
+bool Navmesh::BuildEdgeCenterPath(const Vector2f& aStart, const Vector2f& aGoal, const PathCorridor& aCorridor, FW_GrowingArray<Vector2f>& outWaypoints) const
+{
+	outWaypoints.Add(aStart);
+
+	for (const Portal& portal : aCorridor.myPortals)
+		outWaypoints.Add((portal.myLeft + portal.myRight) / 2.f);
+
+	outWaypoints.Add(aGoal);
+	return true;
+}
+
+bool Navmesh::FindPath(const Vector2f& aStart, const Vector2f& aGoal, FW_GrowingArray<Vector2f>& outWaypoints, PathCorridor& outCorridor) const
+{
+	Triangle* startTriangle = FindTriangleContaining(aStart);
+	Triangle* goalTriangle = FindTriangleContaining(aGoal);
+	if (startTriangle == nullptr || goalTriangle == nullptr)
+		return false;
+
+	if (startTriangle != goalTriangle)
+	{
+		if (!FindTrianglePath(startTriangle, goalTriangle, outCorridor))
+			return false;
+	}
+
+	return BuildEdgeCenterPath(aStart, aGoal, outCorridor, outWaypoints);
+}
+
 Navmesh::Vertex* Navmesh::GetVertex(int x, int y) const
 {
 	int index = mySectorGrid.x * y + x;
@@ -300,15 +483,30 @@ void Navmesh::PerformCut()
 	if (myCutPositions.Count() < 3)
 		return;
 
-	myCutPositions.Add(myCutPositions[0]);
-	for (int i = 0; i < myCutPositions.Count() - 1; ++i)
+	CutPolygon(myCutPositions);
+}
+
+void Navmesh::CutHole(const FW_GrowingArray<Vector2f>& aPolygon)
+{
+	if (aPolygon.Count() < 3)
+		return;
+
+	CutPolygon(aPolygon);
+}
+
+void Navmesh::CutPolygon(const FW_GrowingArray<Vector2f>& aPolygonPoints)
+{
+	FW_GrowingArray<Vector2f> closedPolygon = aPolygonPoints;
+	closedPolygon.Add(closedPolygon[0]);
+
+	for (int i = 0; i < closedPolygon.Count() - 1; ++i)
 	{
-		Cut(myCutPositions[i], myCutPositions[i + 1]);
+		Cut(closedPolygon[i], closedPolygon[i + 1]);
 	}
 
 	for (int i = 0; i < myTriangles.Count(); ++i)
 	{
-		if (IsInsideCutArea(myTriangles[i]))
+		if (IsInsideCutArea(closedPolygon, myTriangles[i]))
 		{
 			DeleteTriangle(myTriangles[i]);
 			--i;
@@ -387,15 +585,15 @@ void Navmesh::CutTriangle(Triangle* aTriangle, Edge* aCutEdge, Vertex* aCutVerte
 	CreateTriangle(centerEdge, oldEdge2, aNewEdge2);
 }
 
-bool Navmesh::IsInsideCutArea(Triangle* aTriangle)
+bool Navmesh::IsInsideCutArea(const FW_GrowingArray<Vector2f>& aCutPositions, Triangle* aTriangle)
 {
 	Vector2f center = aTriangle->GetCenterPosition();
 
-	for (int i = 0; i < myCutPositions.Count() - 1; ++i)
+	for (int i = 0; i < aCutPositions.Count() - 1; ++i)
 	{
 		FW_Intersection::LineSegment cutSegment;
-		cutSegment.myStart = myCutPositions[i];
-		cutSegment.myEnd = myCutPositions[i + 1];
+		cutSegment.myStart = aCutPositions[i];
+		cutSegment.myEnd = aCutPositions[i + 1];
 
 		FW_Intersection::Line cutLine;
 		cutLine.FromSegment(cutSegment);

--- a/Solution/TopDownGame/Navmesh.cpp
+++ b/Solution/TopDownGame/Navmesh.cpp
@@ -151,7 +151,7 @@ Navmesh::Triangle* Navmesh::FindTriangleContaining(const Vector2f& aPosition) co
 	return nullptr;
 }
 
-bool Navmesh::FindTrianglePath(Triangle* aStartTriangle, Triangle* aGoalTriangle, PathCorridor& outCorridor) const
+bool Navmesh::FindTrianglePath(const Vector2f& aStart, Triangle* aStartTriangle, Triangle* aGoalTriangle, PathCorridor& outCorridor) const
 {
 	FW_GrowingArray<AStarNode> nodes;
 
@@ -204,8 +204,19 @@ bool Navmesh::FindTrianglePath(Triangle* aStartTriangle, Triangle* aGoalTriangle
 
 				if (prevLeft == nullptr && prevRight == nullptr)
 				{
-					left = v0;
-					right = v1;
+					// Orient the first portal so it satisfies the funnel algorithm's own
+					// apex/left/right invariant with the initial apex (aStart): the sweep
+					// from left to right around aStart must be non-negative (CCW-or-degenerate).
+					if (Cross(v0->myPos - aStart, v1->myPos - aStart) >= 0.f)
+					{
+						left = v0;
+						right = v1;
+					}
+					else
+					{
+						left = v1;
+						right = v0;
+					}
 				}
 				else if (v0 == prevLeft)
 				{
@@ -307,6 +318,102 @@ bool Navmesh::BuildEdgeCenterPath(const Vector2f& aStart, const Vector2f& aGoal,
 	return true;
 }
 
+namespace
+{
+	float TriArea2(const Vector2f& aA, const Vector2f& aB, const Vector2f& aC)
+	{
+		return Cross(aB - aA, aC - aA);
+	}
+}
+
+bool Navmesh::StringPull(const Vector2f& aStart, const Vector2f& aGoal, const PathCorridor& aCorridor, FW_GrowingArray<Vector2f>& outWaypoints) const
+{
+	if (aCorridor.myPortals.IsEmpty())
+	{
+		outWaypoints.Add(aStart);
+		outWaypoints.Add(aGoal);
+		return true;
+	}
+
+	// "Simple Stupid Funnel Algorithm": portals[0] and portals[Count()-1] are degenerate
+	// (both sides equal to aStart/aGoal) so the loop below can treat every step uniformly.
+	FW_GrowingArray<Vector2f> portalLefts;
+	FW_GrowingArray<Vector2f> portalRights;
+	portalLefts.Add(aStart);
+	portalRights.Add(aStart);
+	for (const Portal& portal : aCorridor.myPortals)
+	{
+		portalLefts.Add(portal.myLeft);
+		portalRights.Add(portal.myRight);
+	}
+	portalLefts.Add(aGoal);
+	portalRights.Add(aGoal);
+
+	outWaypoints.Add(aStart);
+
+	Vector2f apex = aStart;
+	Vector2f left = portalLefts[0];
+	Vector2f right = portalRights[0];
+	int apexIndex = 0;
+	int leftIndex = 0;
+	int rightIndex = 0;
+
+	for (int i = 1; i < portalLefts.Count(); ++i)
+	{
+		const Vector2f& newLeft = portalLefts[i];
+		const Vector2f& newRight = portalRights[i];
+
+		if (TriArea2(apex, right, newRight) <= 0.f)
+		{
+			if (apex == right || TriArea2(apex, left, newRight) > 0.f)
+			{
+				right = newRight;
+				rightIndex = i;
+			}
+			else
+			{
+				outWaypoints.Add(left);
+
+				apex = left;
+				apexIndex = leftIndex;
+				left = apex;
+				right = apex;
+				leftIndex = apexIndex;
+				rightIndex = apexIndex;
+
+				i = apexIndex;
+				continue;
+			}
+		}
+
+		if (TriArea2(apex, left, newLeft) >= 0.f)
+		{
+			if (apex == left || TriArea2(apex, right, newLeft) < 0.f)
+			{
+				left = newLeft;
+				leftIndex = i;
+			}
+			else
+			{
+				outWaypoints.Add(right);
+
+				apex = right;
+				apexIndex = rightIndex;
+				left = apex;
+				right = apex;
+				leftIndex = apexIndex;
+				rightIndex = apexIndex;
+
+				i = apexIndex;
+				continue;
+			}
+		}
+	}
+
+	outWaypoints.Add(aGoal);
+	return true;
+}
+
 bool Navmesh::FindPath(const Vector2f& aStart, const Vector2f& aGoal, FW_GrowingArray<Vector2f>& outWaypoints, PathCorridor& outCorridor) const
 {
 	Triangle* startTriangle = FindTriangleContaining(aStart);
@@ -316,11 +423,11 @@ bool Navmesh::FindPath(const Vector2f& aStart, const Vector2f& aGoal, FW_Growing
 
 	if (startTriangle != goalTriangle)
 	{
-		if (!FindTrianglePath(startTriangle, goalTriangle, outCorridor))
+		if (!FindTrianglePath(aStart, startTriangle, goalTriangle, outCorridor))
 			return false;
 	}
 
-	return BuildEdgeCenterPath(aStart, aGoal, outCorridor, outWaypoints);
+	return StringPull(aStart, aGoal, outCorridor, outWaypoints);
 }
 
 Navmesh::Vertex* Navmesh::GetVertex(int x, int y) const

--- a/Solution/TopDownGame/Navmesh.h
+++ b/Solution/TopDownGame/Navmesh.h
@@ -22,6 +22,7 @@ public:
 	};
 
 	bool BuildEdgeCenterPath(const Vector2f& aStart, const Vector2f& aGoal, const PathCorridor& aCorridor, FW_GrowingArray<Vector2f>& outWaypoints) const;
+	bool StringPull(const Vector2f& aStart, const Vector2f& aGoal, const PathCorridor& aCorridor, FW_GrowingArray<Vector2f>& outWaypoints) const;
 	bool FindPath(const Vector2f& aStart, const Vector2f& aGoal, FW_GrowingArray<Vector2f>& outWaypoints, PathCorridor& outCorridor) const;
 
 	void CutHole(const FW_GrowingArray<Vector2f>& aPolygon);
@@ -82,7 +83,7 @@ private:
 	};
 
 	Triangle* FindTriangleContaining(const Vector2f& aPosition) const;
-	bool FindTrianglePath(Triangle* aStartTriangle, Triangle* aGoalTriangle, PathCorridor& outCorridor) const;
+	bool FindTrianglePath(const Vector2f& aStart, Triangle* aStartTriangle, Triangle* aGoalTriangle, PathCorridor& outCorridor) const;
 
 	Vertex* GetVertex(int x, int y) const;
 	Edge* GetEdgeWithVertex(Vertex* aV, Edge* aE1, Edge* aE2) const;

--- a/Solution/TopDownGame/Navmesh.h
+++ b/Solution/TopDownGame/Navmesh.h
@@ -10,6 +10,22 @@ public:
 	void Update();
 	void Render();
 
+	struct Portal
+	{
+		Vector2f myLeft;
+		Vector2f myRight;
+	};
+
+	struct PathCorridor
+	{
+		FW_GrowingArray<Portal> myPortals;
+	};
+
+	bool BuildEdgeCenterPath(const Vector2f& aStart, const Vector2f& aGoal, const PathCorridor& aCorridor, FW_GrowingArray<Vector2f>& outWaypoints) const;
+	bool FindPath(const Vector2f& aStart, const Vector2f& aGoal, FW_GrowingArray<Vector2f>& outWaypoints, PathCorridor& outCorridor) const;
+
+	void CutHole(const FW_GrowingArray<Vector2f>& aPolygon);
+
 private:
 	struct Vertex;
 	struct Edge;
@@ -55,6 +71,19 @@ private:
 		Vector2f myCutPosition;
 	};
 
+	struct AStarNode
+	{
+		Triangle* myTriangle = nullptr;
+		Edge* myEdgeFromParent = nullptr;
+		int myParentIndex = -1;
+		float myGCost = 0.f;
+		float myFCost = 0.f;
+		bool myIsClosed = false;
+	};
+
+	Triangle* FindTriangleContaining(const Vector2f& aPosition) const;
+	bool FindTrianglePath(Triangle* aStartTriangle, Triangle* aGoalTriangle, PathCorridor& outCorridor) const;
+
 	Vertex* GetVertex(int x, int y) const;
 	Edge* GetEdgeWithVertex(Vertex* aV, Edge* aE1, Edge* aE2) const;
 	Edge* GetEdgeWithoutVertex(Vertex* aV, Edge* aE1, Edge* aE2) const;
@@ -71,11 +100,12 @@ private:
 	void DeleteTriangle(Triangle* aTriangle);
 
 	void PerformCut();
+	void CutPolygon(const FW_GrowingArray<Vector2f>& aPolygonPoints);
 	void Cut(const Vector2f& aV1, const Vector2f& aV2);
 	void CollectCutEdges(const FW_Intersection::LineSegment& aCuttingLine, FW_GrowingArray<CutEdge>& outCutEdges) const;
 	void CutTriangle(Triangle* aTriangle, Edge* aCutEdge, Vertex* aCutVertex, Edge* aNewEdge1, Edge* aNewEdge2);
 
-	bool IsInsideCutArea(Triangle* aTriangle);
+	bool IsInsideCutArea(const FW_GrowingArray<Vector2f>& aCutPositions, Triangle* aTriangle);
 
 	FW_GrowingArray<Vertex*> myVertices;
 	FW_GrowingArray<Edge*> myEdges;

--- a/Solution/TopDownGame/NavmeshTestSuite.cpp
+++ b/Solution/TopDownGame/NavmeshTestSuite.cpp
@@ -5,6 +5,15 @@
 
 namespace NavmeshTestSuite
 {
+	float GetTotalPathLength(const FW_GrowingArray<Vector2f>& aWaypoints)
+	{
+		float length = 0.f;
+		for (int i = 0; i < aWaypoints.Count() - 1; ++i)
+			length += Length(aWaypoints[i + 1] - aWaypoints[i]);
+
+		return length;
+	}
+
 	void TestFindPathSucceedsBetweenReachablePoints()
 	{
 		Navmesh mesh;
@@ -77,11 +86,75 @@ namespace NavmeshTestSuite
 		FW_ASSERT(waypoints[1] == goal, "Expected second waypoint to be the goal position");
 	}
 
+	void TestStringPullIsNoLongerThanEdgeCenterPath()
+	{
+		Navmesh mesh;
+
+		// A block that leaves room above and below, so the corridor between start and goal
+		// has to bend around it rather than running straight through.
+		FW_GrowingArray<Vector2f> cutBlock;
+		cutBlock.Add(Vector2f{ 860.f, 300.f });
+		cutBlock.Add(Vector2f{ 1100.f, 300.f });
+		cutBlock.Add(Vector2f{ 1100.f, 636.f });
+		cutBlock.Add(Vector2f{ 860.f, 636.f });
+		mesh.CutHole(cutBlock);
+
+		Vector2f start{ 50.f, 468.f };
+		Vector2f goal{ 1900.f, 468.f };
+
+		FW_GrowingArray<Vector2f> stringPulledWaypoints;
+		Navmesh::PathCorridor corridor;
+		bool found = mesh.FindPath(start, goal, stringPulledWaypoints, corridor);
+
+		FW_ASSERT(found, "Expected FindPath to succeed by routing around the cut");
+		FW_ASSERT(corridor.myPortals.Count() > 1, "Expected a multi-portal corridor bending around the cut");
+
+		FW_GrowingArray<Vector2f> edgeCenterWaypoints;
+		mesh.BuildEdgeCenterPath(start, goal, corridor, edgeCenterWaypoints);
+
+		FW_ASSERT(GetTotalPathLength(stringPulledWaypoints) <= GetTotalPathLength(edgeCenterWaypoints),
+			"Expected the string-pulled path to be no longer than the edge-center path through the same corridor");
+	}
+
+	void TestStringPullCanReFunnelAnExistingCorridorFromANewStart()
+	{
+		Navmesh mesh;
+
+		FW_GrowingArray<Vector2f> cutBlock;
+		cutBlock.Add(Vector2f{ 860.f, 300.f });
+		cutBlock.Add(Vector2f{ 1100.f, 300.f });
+		cutBlock.Add(Vector2f{ 1100.f, 636.f });
+		cutBlock.Add(Vector2f{ 860.f, 636.f });
+		mesh.CutHole(cutBlock);
+
+		Vector2f start{ 50.f, 468.f };
+		Vector2f goal{ 1900.f, 468.f };
+
+		FW_GrowingArray<Vector2f> waypoints;
+		Navmesh::PathCorridor corridor;
+		bool found = mesh.FindPath(start, goal, waypoints, corridor);
+		FW_ASSERT(found, "Expected the initial FindPath to succeed");
+
+		// Simulate an entity that has moved partway along its route: re-funnel the same,
+		// already-computed corridor from a new position without running a new search.
+		Vector2f partwayPosition{ 300.f, 468.f };
+
+		FW_GrowingArray<Vector2f> reFunneledWaypoints;
+		bool reFunneled = mesh.StringPull(partwayPosition, goal, corridor, reFunneledWaypoints);
+
+		FW_ASSERT(reFunneled, "Expected StringPull to succeed when re-funneling a stored corridor");
+		FW_ASSERT(reFunneledWaypoints.Count() >= 2, "Expected at least a start and goal waypoint");
+		FW_ASSERT(reFunneledWaypoints[0] == partwayPosition, "Expected first waypoint to be the new start position");
+		FW_ASSERT(reFunneledWaypoints.GetLast() == goal, "Expected last waypoint to be the goal position");
+	}
+
 	void RunTests()
 	{
 		TestFindPathSucceedsBetweenReachablePoints();
 		TestFindPathFailsOutsideMesh();
 		TestFindPathFailsWhenCutDisconnectsStartFromGoal();
 		TestFindPathSameTriangleYieldsStraightPath();
+		TestStringPullIsNoLongerThanEdgeCenterPath();
+		TestStringPullCanReFunnelAnExistingCorridorFromANewStart();
 	}
 }

--- a/Solution/TopDownGame/NavmeshTestSuite.cpp
+++ b/Solution/TopDownGame/NavmeshTestSuite.cpp
@@ -1,0 +1,87 @@
+#include "stdafx.h"
+
+#include "NavmeshTestSuite.h"
+#include "Navmesh.h"
+
+namespace NavmeshTestSuite
+{
+	void TestFindPathSucceedsBetweenReachablePoints()
+	{
+		Navmesh mesh;
+
+		Vector2f start{ 50.f, 50.f };
+		Vector2f goal{ 1900.f, 850.f };
+
+		FW_GrowingArray<Vector2f> waypoints;
+		Navmesh::PathCorridor corridor;
+		bool found = mesh.FindPath(start, goal, waypoints, corridor);
+
+		FW_ASSERT(found, "Expected FindPath to succeed between two reachable points");
+		FW_ASSERT(waypoints.Count() >= 2, "Expected at least a start and goal waypoint");
+		FW_ASSERT(waypoints[0] == start, "Expected first waypoint to be the start position");
+		FW_ASSERT(waypoints.GetLast() == goal, "Expected last waypoint to be the goal position");
+	}
+
+	void TestFindPathFailsOutsideMesh()
+	{
+		Navmesh mesh;
+
+		Vector2f start{ -100.f, -100.f };
+		Vector2f goal{ 50.f, 50.f };
+
+		FW_GrowingArray<Vector2f> waypoints;
+		Navmesh::PathCorridor corridor;
+		bool found = mesh.FindPath(start, goal, waypoints, corridor);
+
+		FW_ASSERT(!found, "Expected FindPath to fail when the start position is outside the mesh");
+		FW_ASSERT(waypoints.IsEmpty(), "Expected no waypoints for a failed path");
+	}
+
+	void TestFindPathFailsWhenCutDisconnectsStartFromGoal()
+	{
+		Navmesh mesh;
+
+		// A horizontal band spanning wider than the mesh, cutting it into a top half and a bottom half.
+		FW_GrowingArray<Vector2f> cutBand;
+		cutBand.Add(Vector2f{ -50.f, 450.f });
+		cutBand.Add(Vector2f{ 2000.f, 450.f });
+		cutBand.Add(Vector2f{ 2000.f, 480.f });
+		cutBand.Add(Vector2f{ -50.f, 480.f });
+		mesh.CutHole(cutBand);
+
+		Vector2f start{ 50.f, 100.f };
+		Vector2f goal{ 1900.f, 800.f };
+
+		FW_GrowingArray<Vector2f> waypoints;
+		Navmesh::PathCorridor corridor;
+		bool found = mesh.FindPath(start, goal, waypoints, corridor);
+
+		FW_ASSERT(!found, "Expected FindPath to fail once a full-width cut disconnects start from goal");
+	}
+
+	void TestFindPathSameTriangleYieldsStraightPath()
+	{
+		Navmesh mesh;
+
+		Vector2f start{ 30.f, 30.f };
+		Vector2f goal{ 40.f, 35.f };
+
+		FW_GrowingArray<Vector2f> waypoints;
+		Navmesh::PathCorridor corridor;
+		bool found = mesh.FindPath(start, goal, waypoints, corridor);
+
+		FW_ASSERT(found, "Expected FindPath to succeed for a same-triangle start/goal");
+		FW_ASSERT(corridor.myPortals.IsEmpty(), "Expected a zero-portal corridor for a same-triangle path");
+		FW_ASSERT(waypoints.Count() == 2, "Expected a 2-waypoint straight path for a same-triangle start/goal");
+		FW_ASSERT(waypoints[0] == start, "Expected first waypoint to be the start position");
+		FW_ASSERT(waypoints[1] == goal, "Expected second waypoint to be the goal position");
+	}
+
+	void RunTests()
+	{
+		TestFindPathSucceedsBetweenReachablePoints();
+		TestFindPathFailsOutsideMesh();
+		TestFindPathFailsWhenCutDisconnectsStartFromGoal();
+		TestFindPathSameTriangleYieldsStraightPath();
+	}
+}

--- a/Solution/TopDownGame/NavmeshTestSuite.h
+++ b/Solution/TopDownGame/NavmeshTestSuite.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace NavmeshTestSuite
+{
+	void RunTests();
+}

--- a/Solution/TopDownGame/TopDownGame.vcxproj
+++ b/Solution/TopDownGame/TopDownGame.vcxproj
@@ -143,6 +143,7 @@
   <ItemGroup>
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Navmesh.cpp" />
+    <ClCompile Include="NavmeshTestSuite.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
@@ -150,6 +151,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Navmesh.h" />
+    <ClInclude Include="NavmeshTestSuite.h" />
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Solution/TopDownGame/TopDownGame.vcxproj.filters
+++ b/Solution/TopDownGame/TopDownGame.vcxproj.filters
@@ -4,9 +4,11 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="Navmesh.cpp" />
+    <ClCompile Include="NavmeshTestSuite.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="Navmesh.h" />
+    <ClInclude Include="NavmeshTestSuite.h" />
   </ItemGroup>
 </Project>

--- a/Solution/TopDownGame/main.cpp
+++ b/Solution/TopDownGame/main.cpp
@@ -8,6 +8,7 @@
 #include "Core/Input.h"
 
 #include "Navmesh.h"
+#include "NavmeshTestSuite.h"
 
 class App : public Slush::IApp
 {
@@ -51,6 +52,7 @@ private:
 int main(int argc, char** argv)
 {
 	FW_UnitTestSuite::RunTests();
+	NavmeshTestSuite::RunTests();
 
 	Slush::CommandLineArgs::GetInstance().Parse(argc, argv);
 


### PR DESCRIPTION
## Description

Add A* pathfinding over the triangle navmesh's adjacency graph, returning a portal-edge `PathCorridor` plus two swappable ways to turn it into waypoints: a trivial edge-center path, and a proper funnel/string-pulled path re-runnable on an already-computed corridor without re-searching.

Closes #58

## Agent End-of-run Summary

Both phases of #58 are complete:
- Phase 1 (`ac80b08`): `Portal`/`PathCorridor` types, private `FindTriangleContaining` + a linear-scan A* search over the triangle adjacency graph, `BuildEdgeCenterPath`, and the public `FindPath` entry point. Since #62 (black-box Navmesh test harness) hasn't landed yet, added minimal `NavmeshTestSuite` scaffolding inline (mirroring `FW_UnitTestSuite`'s free-function shape) plus a small public `Navmesh::CutHole(polygon)` helper so tests can carve a hole without going through the mouse-driven `Update()`/`PerformCut()` flow.
- Phase 2 (`d1739f5`): `StringPull` implementing the standard funnel algorithm over a `PathCorridor`'s portals, with `FindPath` switched to use it by default. Portal left/right orientation for the very first crossed edge is chosen to satisfy the funnel algorithm's own apex invariant relative to the actual start position (rather than an arbitrary choice), with subsequent portals' orientation propagated via shared-vertex continuity — a design decision not spelled out in the issue text, needed to make `StringPull` produce a geometrically valid taut path.

An automatic review pass (a fresh subagent, given the issue text and the full diff) found one real correctness bug: `FindPath`/`BuildEdgeCenterPath`/`StringPull` never cleared their out-params before populating them, so the issue's explicit "zero-portal corridor" guarantee for a same-triangle `FindPath`, and the "populate outWaypoints" contract, only held by accident of callers passing fresh empty containers each call — which breaks for the corridor-reuse pattern (an entity re-funneling a stored `PathCorridor` every frame) this issue exists to enable. Fixed in `cb90e3d`: `FindPath` now builds into a local corridor and only assigns it into `outCorridor` once the search has succeeded (replaced, not appended to, on success; genuinely untouched on failure); `BuildEdgeCenterPath`/`StringPull` now clear `outWaypoints` up front (safe since neither has a failure path).

Each phase was verified by building the full solution (MSBuild, Debug|x86) and launching `TopDownGame.exe -hidewindow`, confirming `NavmeshTestSuite::RunTests()` (called at startup, before engine init) completes without triggering an `FW_ASSERT` crash — 6 test cases total, covering: a successful multi-triangle path with correct first/last waypoints; failure for a start outside the mesh; failure when a full-width `CutHole` disconnects start from goal; a same-triangle 2-waypoint straight path; a multi-portal corridor bending around a cut where the string-pulled length is ≤ the edge-center path length; and re-funneling a stored corridor from a new start position via `StringPull` alone.

Please review the committed changes on the `issue-58` branch before deciding whether this is done or needs more work.

## Agent Verifications

**Phase 1**: Built the full solution (MSBuild, Debug|x86) after adding `Portal`/`PathCorridor`, `FindTriangleContaining`, the A* search, `BuildEdgeCenterPath`, `FindPath`, `CutHole`, and the `NavmeshTestSuite` scaffolding. Launched `TopDownGame.exe -hidewindow` and confirmed the 4 new `NavmeshTestSuite` cases pass (no `FW_ASSERT` crash): `FindPath` success with correct first/last waypoints, failure outside the mesh, failure across a full-width cut, and a same-triangle zero-portal 2-waypoint path.

**Phase 2**: Built the full solution again after adding `StringPull` and switching `FindPath`'s internal call to it. Launched `TopDownGame.exe -hidewindow` and confirmed all 6 `NavmeshTestSuite` cases pass, including the 2 new ones: a multi-portal corridor where the string-pulled path length is ≤ the edge-center path length built from the same corridor, and a re-funneling case that calls `StringPull` a second time with a different start position on an already-computed corridor, without a new search.
