### PR TITLE
Navmesh cut-precision fix and unit-test harness (TopDownGame)

### DIFF
--- a/Solution/TopDownGame/Navmesh.cpp
+++ b/Solution/TopDownGame/Navmesh.cpp
@@ -609,6 +609,27 @@ void Navmesh::CutHole(const FW_GrowingArray<Vector2f>& aPolygon)
 	CutPolygon(aPolygon);
 }
 
+int Navmesh::GetTriangleCount() const
+{
+	return myTriangles.Count();
+}
+
+int Navmesh::GetVertexCount() const
+{
+	return myVertices.Count();
+}
+
+bool Navmesh::HasVertexNear(const Vector2f& aPosition, float anEpsilon) const
+{
+	for (Vertex* vertex : myVertices)
+	{
+		if (Length2(vertex->myPos - aPosition) <= anEpsilon * anEpsilon)
+			return true;
+	}
+
+	return false;
+}
+
 void Navmesh::CutPolygon(const FW_GrowingArray<Vector2f>& aPolygonPoints)
 {
 	FW_GrowingArray<Vector2f> closedPolygon = aPolygonPoints;

--- a/Solution/TopDownGame/Navmesh.cpp
+++ b/Solution/TopDownGame/Navmesh.cpp
@@ -621,17 +621,13 @@ int Navmesh::GetVertexCount() const
 
 bool Navmesh::HasVertexNear(const Vector2f& aPosition, float anEpsilon) const
 {
-	for (Vertex* vertex : myVertices)
-	{
-		if (Length2(vertex->myPos - aPosition) <= anEpsilon * anEpsilon)
-			return true;
-	}
-
-	return false;
+	return FindNearbyVertex(aPosition, anEpsilon) != nullptr;
 }
 
 void Navmesh::CutPolygon(const FW_GrowingArray<Vector2f>& aPolygonPoints)
 {
+	EnsureCutterVerticesExist(aPolygonPoints);
+
 	FW_GrowingArray<Vector2f> closedPolygon = aPolygonPoints;
 	closedPolygon.Add(closedPolygon[0]);
 
@@ -650,14 +646,39 @@ void Navmesh::CutPolygon(const FW_GrowingArray<Vector2f>& aPolygonPoints)
 	}
 }
 
+namespace
+{
+	const float CutterVertexEpsilon = 1.f;
+}
+
+void Navmesh::EnsureCutterVerticesExist(const FW_GrowingArray<Vector2f>& aPolygonPoints)
+{
+	// A cutter shape's own corner points are never guaranteed to land on an existing mesh edge, so
+	// without this step Cut()'s edge-crossing logic below only ever creates vertices where a cut
+	// segment crosses an *existing* edge - the shape's own corners can fall anywhere inside a
+	// triangle and drift from the clicked/authored positions. Snapping within CutterVertexEpsilon
+	// instead of always inserting exactly avoids scattering near-duplicate vertices/edges a hair's
+	// width apart from whatever's already there (e.g. re-cutting close to a previous cut's own
+	// corners, or a corner that's already effectively on a shared edge/vertex by construction).
+	// The remaining imprecision is bounded by the epsilon rather than by triangle size.
+	for (const Vector2f& point : aPolygonPoints)
+	{
+		if (FindNearbyVertex(point, CutterVertexEpsilon) != nullptr)
+			continue;
+
+		if (Edge* nearbyEdge = FindNearbyEdge(point, CutterVertexEpsilon))
+		{
+			SplitEdgeAtPosition(nearbyEdge, point);
+			continue;
+		}
+
+		if (Triangle* triangle = FindTriangleContaining(point))
+			InsertVertexInTriangle(triangle, point);
+	}
+}
+
 void Navmesh::Cut(const Vector2f& aV1, const Vector2f& aV2)
 {
-	// There is not guarantee that there will be a Vertex created exactly at aV1 and aV2, so the
-	// further away from an edge those postions are within a triangle, the less accurate the cut becomes
-	// in that triangle.
-	// Ideally a Vertex should always be created on those specific positions, but that also makes the
-	// cutting more complex.
-
 	FW_Intersection::LineSegment cuttingLine;
 	cuttingLine.myStart = aV1;
 	cuttingLine.myEnd = aV2;
@@ -688,6 +709,13 @@ void Navmesh::Cut(const Vector2f& aV1, const Vector2f& aV2)
 
 void Navmesh::CollectCutEdges(const FW_Intersection::LineSegment& aCuttingLine, FW_GrowingArray<CutEdge>& outCutEdges) const
 {
+	// LineSegmentVsLineSegment's general (non-parallel) case is endpoint-inclusive, so a cutting
+	// segment that starts/ends exactly on an existing vertex (as EnsureCutterVerticesExist now
+	// guarantees) reports a spurious "crossing" against every edge incident to that vertex, right
+	// at the segment's own endpoint. That's not an interior crossing needing a new vertex there -
+	// the vertex already exists - so skip any hit that lands on the cutting segment's own start/end.
+	const float DegenerateEpsilonSq = 0.0001f;
+
 	FW_Intersection::LineSegment edgeSegment;
 	Vector2f intersectionPoint;
 	for (Edge* edge : myEdges)
@@ -696,11 +724,99 @@ void Navmesh::CollectCutEdges(const FW_Intersection::LineSegment& aCuttingLine, 
 		edgeSegment.myEnd = edge->myVertices[1]->myPos;
 		if (FW_Intersection::LineSegmentVsLineSegment(aCuttingLine, edgeSegment, &intersectionPoint))
 		{
+			if (Length2(intersectionPoint - aCuttingLine.myStart) <= DegenerateEpsilonSq)
+				continue;
+			if (Length2(intersectionPoint - aCuttingLine.myEnd) <= DegenerateEpsilonSq)
+				continue;
+
 			CutEdge& cutEdge = outCutEdges.Add();
 			cutEdge.myEdge = edge;
 			cutEdge.myCutPosition = intersectionPoint;
 		}
 	}
+}
+
+Navmesh::Vertex* Navmesh::InsertVertexInTriangle(Triangle* aTriangle, const Vector2f& aPosition)
+{
+	Vertex* newVertex = CreateVertex(aPosition);
+
+	Vertex* v0 = aTriangle->myVertices[0];
+	Vertex* v1 = aTriangle->myVertices[1];
+	Vertex* v2 = aTriangle->myVertices[2];
+
+	Edge* edge01 = aTriangle->GetEdgeWithoutVertex(v2);
+	Edge* edge12 = aTriangle->GetEdgeWithoutVertex(v0);
+	Edge* edge20 = aTriangle->GetEdgeWithoutVertex(v1);
+
+	Edge* spoke0 = CreateEdge(newVertex, v0);
+	Edge* spoke1 = CreateEdge(newVertex, v1);
+	Edge* spoke2 = CreateEdge(newVertex, v2);
+
+	myTriangles.DeleteCyclic(aTriangle);
+
+	CreateTriangle(edge01, spoke0, spoke1);
+	CreateTriangle(edge12, spoke1, spoke2);
+	CreateTriangle(edge20, spoke2, spoke0);
+
+	return newVertex;
+}
+
+Navmesh::Vertex* Navmesh::SplitEdgeAtPosition(Edge* aEdge, const Vector2f& aPosition)
+{
+	Vertex* cutVertex = CreateVertex(aPosition);
+
+	Edge* newEdge1 = CreateEdge(aEdge->myVertices[0], cutVertex);
+	Edge* newEdge2 = CreateEdge(cutVertex, aEdge->myVertices[1]);
+
+	Triangle* triangle0 = aEdge->myTriangles[0];
+	Triangle* triangle1 = aEdge->myTriangles[1];
+
+	CutTriangle(triangle0, aEdge, cutVertex, newEdge1, newEdge2);
+	CutTriangle(triangle1, aEdge, cutVertex, newEdge1, newEdge2);
+
+	if (triangle0)
+		DeleteTriangle(triangle0);
+	if (triangle1)
+		DeleteTriangle(triangle1);
+
+	return cutVertex;
+}
+
+Navmesh::Vertex* Navmesh::FindNearbyVertex(const Vector2f& aPosition, float anEpsilon) const
+{
+	for (Vertex* vertex : myVertices)
+	{
+		if (Length2(vertex->myPos - aPosition) <= anEpsilon * anEpsilon)
+			return vertex;
+	}
+
+	return nullptr;
+}
+
+namespace
+{
+	float DistancePointToSegmentSq(const Vector2f& aPoint, const Vector2f& aSegmentStart, const Vector2f& aSegmentEnd)
+	{
+		Vector2f segmentDir = aSegmentEnd - aSegmentStart;
+		float segmentLength2 = Length2(segmentDir);
+		if (segmentLength2 == 0.f)
+			return Length2(aPoint - aSegmentStart);
+
+		float t = FW_Clamp(Dot(aPoint - aSegmentStart, segmentDir) / segmentLength2, 0.f, 1.f);
+		Vector2f closestPoint = aSegmentStart + segmentDir * t;
+		return Length2(aPoint - closestPoint);
+	}
+}
+
+Navmesh::Edge* Navmesh::FindNearbyEdge(const Vector2f& aPosition, float anEpsilon) const
+{
+	for (Edge* edge : myEdges)
+	{
+		if (DistancePointToSegmentSq(aPosition, edge->myVertices[0]->myPos, edge->myVertices[1]->myPos) <= anEpsilon * anEpsilon)
+			return edge;
+	}
+
+	return nullptr;
 }
 
 void Navmesh::CutTriangle(Triangle* aTriangle, Edge* aCutEdge, Vertex* aCutVertex, Edge* aNewEdge1, Edge* aNewEdge2)

--- a/Solution/TopDownGame/Navmesh.h
+++ b/Solution/TopDownGame/Navmesh.h
@@ -106,9 +106,15 @@ private:
 
 	void PerformCut();
 	void CutPolygon(const FW_GrowingArray<Vector2f>& aPolygonPoints);
+	void EnsureCutterVerticesExist(const FW_GrowingArray<Vector2f>& aPolygonPoints);
 	void Cut(const Vector2f& aV1, const Vector2f& aV2);
 	void CollectCutEdges(const FW_Intersection::LineSegment& aCuttingLine, FW_GrowingArray<CutEdge>& outCutEdges) const;
 	void CutTriangle(Triangle* aTriangle, Edge* aCutEdge, Vertex* aCutVertex, Edge* aNewEdge1, Edge* aNewEdge2);
+
+	Vertex* InsertVertexInTriangle(Triangle* aTriangle, const Vector2f& aPosition);
+	Vertex* SplitEdgeAtPosition(Edge* aEdge, const Vector2f& aPosition);
+	Vertex* FindNearbyVertex(const Vector2f& aPosition, float anEpsilon) const;
+	Edge* FindNearbyEdge(const Vector2f& aPosition, float anEpsilon) const;
 
 	bool IsInsideCutArea(const FW_GrowingArray<Vector2f>& aCutPositions, Triangle* aTriangle);
 

--- a/Solution/TopDownGame/Navmesh.h
+++ b/Solution/TopDownGame/Navmesh.h
@@ -27,6 +27,10 @@ public:
 
 	void CutHole(const FW_GrowingArray<Vector2f>& aPolygon);
 
+	int GetTriangleCount() const;
+	int GetVertexCount() const;
+	bool HasVertexNear(const Vector2f& aPosition, float anEpsilon) const;
+
 private:
 	struct Vertex;
 	struct Edge;

--- a/Solution/TopDownGame/NavmeshTestSuite.cpp
+++ b/Solution/TopDownGame/NavmeshTestSuite.cpp
@@ -215,11 +215,31 @@ namespace NavmeshTestSuite
 		FW_ASSERT(mesh.GetVertexCount() == initialVertexCount, "Expected snapping to already-existing vertices to add no new vertices");
 	}
 
+	void TestCutterCornerNearExistingEdgeSnapsOntoThatEdge()
+	{
+		Navmesh mesh;
+
+		// A point close to (but not exactly on, and well clear of either endpoint of) one interior
+		// quad's own top edge - should snap onto that edge via SplitEdgeAtPosition rather than
+		// falling into the triangle-interior insertion path.
+		Vector2f cornerNearEdge{ 724.f, 404.3f };
+		FW_ASSERT(!mesh.HasVertexNear(cornerNearEdge, 0.01f), "Test setup: expected no existing vertex at this position");
+
+		FW_GrowingArray<Vector2f> cutterCorners;
+		cutterCorners.Add(cornerNearEdge);
+		cutterCorners.Add(Vector2f{ 700.f, 460.f });
+		cutterCorners.Add(Vector2f{ 748.f, 460.f });
+		mesh.CutHole(cutterCorners);
+
+		FW_ASSERT(mesh.HasVertexNear(cornerNearEdge, 0.01f), "Expected a vertex snapped onto the nearby edge at the cutter's own corner position");
+	}
+
 	void RunTests()
 	{
 		TestCutAcrossOneQuadProducesExpectedCounts();
 		TestCutterCornerInsideTriangleInteriorProducesVertexThere();
 		TestCutterCornerNearExistingVertexSnapsInsteadOfDuplicating();
+		TestCutterCornerNearExistingEdgeSnapsOntoThatEdge();
 		TestFindPathSucceedsBetweenReachablePoints();
 		TestFindPathFailsOutsideMesh();
 		TestFindPathFailsWhenCutDisconnectsStartFromGoal();

--- a/Solution/TopDownGame/NavmeshTestSuite.cpp
+++ b/Solution/TopDownGame/NavmeshTestSuite.cpp
@@ -159,7 +159,10 @@ namespace NavmeshTestSuite
 
 		// A thin band entirely inside one interior quad, crossing its diagonal edge twice (once on
 		// each of the band's long sides). All 4 corners sit deep inside triangle interiors - away
-		// from any existing vertex or edge - so this exercises the plain edge-crossing cut path only.
+		// from any existing vertex or edge - so besides the 2 diagonal crossings, each of the 4
+		// corners now also gets its own precise vertex inserted (the Phase 2 fix - see
+		// EnsureCutterVerticesExist). Before that fix landed this produced only +2/+2; the higher
+		// counts here are the new, correct behavior, not a regression.
 		FW_GrowingArray<Vector2f> cutterCorners;
 		cutterCorners.Add(Vector2f{ 700.f, 440.f });
 		cutterCorners.Add(Vector2f{ 748.f, 440.f });
@@ -167,13 +170,56 @@ namespace NavmeshTestSuite
 		cutterCorners.Add(Vector2f{ 700.f, 496.f });
 		mesh.CutHole(cutterCorners);
 
-		FW_ASSERT(mesh.GetTriangleCount() == initialTriangleCount + 2, "Expected the two diagonal crossings to add exactly 2 triangles");
-		FW_ASSERT(mesh.GetVertexCount() == initialVertexCount + 2, "Expected the two diagonal crossings to add exactly 2 vertices");
+		FW_ASSERT(mesh.GetTriangleCount() == initialTriangleCount + 10, "Expected the 2 diagonal crossings plus 4 precise corner insertions to add exactly 10 triangles");
+		FW_ASSERT(mesh.GetVertexCount() == initialVertexCount + 8, "Expected the 2 diagonal crossings plus 4 precise corner insertions to add exactly 8 vertices");
+		FW_ASSERT(mesh.HasVertexNear(Vector2f{ 700.f, 440.f }, 0.01f), "Expected a precise vertex at the cutter's own corner position");
+	}
+
+	void TestCutterCornerInsideTriangleInteriorProducesVertexThere()
+	{
+		Navmesh mesh;
+
+		Vector2f cornerDeepInsideATriangle{ 45.f, 45.f };
+		FW_ASSERT(!mesh.HasVertexNear(cornerDeepInsideATriangle, 0.01f), "Test setup: expected no existing vertex at this position");
+
+		FW_GrowingArray<Vector2f> cutterCorners;
+		cutterCorners.Add(cornerDeepInsideATriangle);
+		cutterCorners.Add(Vector2f{ 60.f, 45.f });
+		cutterCorners.Add(Vector2f{ 45.f, 60.f });
+		mesh.CutHole(cutterCorners);
+
+		FW_ASSERT(mesh.HasVertexNear(cornerDeepInsideATriangle, 0.01f), "Expected a precise vertex at the cutter corner that landed inside a triangle's interior");
+	}
+
+	void TestCutterCornerNearExistingVertexSnapsInsteadOfDuplicating()
+	{
+		Navmesh mesh;
+
+		// The exact 3 vertices of one interior quad's own upper-left triangle - already real navmesh
+		// vertices, so EnsureCutterVerticesExist should snap to each rather than inserting a
+		// near-duplicate for any of them.
+		Vector2f topLeft{ 660.f, 404.f };
+		Vector2f topRight{ 788.f, 404.f };
+		Vector2f bottomLeft{ 660.f, 532.f };
+		FW_ASSERT(mesh.HasVertexNear(topLeft, 0.01f) && mesh.HasVertexNear(topRight, 0.01f) && mesh.HasVertexNear(bottomLeft, 0.01f),
+			"Test setup: expected these to already be real navmesh vertices");
+
+		const int initialVertexCount = mesh.GetVertexCount();
+
+		FW_GrowingArray<Vector2f> cutterCorners;
+		cutterCorners.Add(topLeft);
+		cutterCorners.Add(topRight);
+		cutterCorners.Add(bottomLeft);
+		mesh.CutHole(cutterCorners);
+
+		FW_ASSERT(mesh.GetVertexCount() == initialVertexCount, "Expected snapping to already-existing vertices to add no new vertices");
 	}
 
 	void RunTests()
 	{
 		TestCutAcrossOneQuadProducesExpectedCounts();
+		TestCutterCornerInsideTriangleInteriorProducesVertexThere();
+		TestCutterCornerNearExistingVertexSnapsInsteadOfDuplicating();
 		TestFindPathSucceedsBetweenReachablePoints();
 		TestFindPathFailsOutsideMesh();
 		TestFindPathFailsWhenCutDisconnectsStartFromGoal();

--- a/Solution/TopDownGame/NavmeshTestSuite.cpp
+++ b/Solution/TopDownGame/NavmeshTestSuite.cpp
@@ -148,8 +148,32 @@ namespace NavmeshTestSuite
 		FW_ASSERT(reFunneledWaypoints.GetLast() == goal, "Expected last waypoint to be the goal position");
 	}
 
+	void TestCutAcrossOneQuadProducesExpectedCounts()
+	{
+		Navmesh mesh;
+
+		const int initialTriangleCount = mesh.GetTriangleCount();
+		const int initialVertexCount = mesh.GetVertexCount();
+		FW_ASSERT(initialTriangleCount == 210, "Expected the default sector grid to produce 210 triangles");
+		FW_ASSERT(initialVertexCount == 128, "Expected the default sector grid to produce 128 vertices");
+
+		// A thin band entirely inside one interior quad, crossing its diagonal edge twice (once on
+		// each of the band's long sides). All 4 corners sit deep inside triangle interiors - away
+		// from any existing vertex or edge - so this exercises the plain edge-crossing cut path only.
+		FW_GrowingArray<Vector2f> cutterCorners;
+		cutterCorners.Add(Vector2f{ 700.f, 440.f });
+		cutterCorners.Add(Vector2f{ 748.f, 440.f });
+		cutterCorners.Add(Vector2f{ 748.f, 496.f });
+		cutterCorners.Add(Vector2f{ 700.f, 496.f });
+		mesh.CutHole(cutterCorners);
+
+		FW_ASSERT(mesh.GetTriangleCount() == initialTriangleCount + 2, "Expected the two diagonal crossings to add exactly 2 triangles");
+		FW_ASSERT(mesh.GetVertexCount() == initialVertexCount + 2, "Expected the two diagonal crossings to add exactly 2 vertices");
+	}
+
 	void RunTests()
 	{
+		TestCutAcrossOneQuadProducesExpectedCounts();
 		TestFindPathSucceedsBetweenReachablePoints();
 		TestFindPathFailsOutsideMesh();
 		TestFindPathFailsWhenCutDisconnectsStartFromGoal();


### PR DESCRIPTION
## Description

Insert a precise vertex at every cutter-shape corner during a Navmesh cut, and establish a first, minimal black-box unit-test harness for `Navmesh`.

Closes #62

## Agent End-of-run Summary

Both phases of issue #62 are implemented, verified, and reviewed. Here's the end-of-run summary:

**Phases completed:**
- **Phase 1** (`39429df`): Added the black-box query API (`GetTriangleCount`/`GetVertexCount`/`HasVertexNear`) and a baseline regression test for current cut behavior.
- **Phase 2** (`03c62fb`): Added `EnsureCutterVerticesExist`, which guarantees a real vertex at every cutter-shape corner — via `InsertVertexInTriangle` (new), snapping onto a nearby edge via `SplitEdgeAtPosition` (new), or snapping to an already-existing vertex — plus 3 new test cases.
- **Follow-up** (`0e5488d`): Added a 4th test case covering the edge-snap path, per the review pass below.

**Notable things hit while working autonomously:**
- While designing Phase 1's baseline test, I discovered `LineSegmentVsLineSegment`'s general-case intersection check is endpoint-inclusive, which caused massive spurious "crossings" (empirically: 210→231 triangles, 128→150 vertices, for a cut whose corners sat exactly on existing vertices) — a pre-existing bug, not something I introduced. This is exactly the "degenerate crossings" risk the issue's own Phase 2 text flagged, so I fixed it in `CollectCutEdges` as part of Phase 2.
- **Judgment call worth your attention:** the issue's Phase 2 text asked for the Phase 1 baseline test to "still pass unmodified" after Phase 2 landed. I determined this is mathematically not achievable for any non-trivial cutter — correctly making every cutter corner a real vertex necessarily changes the resulting triangle/vertex counts for any cutter whose corners aren't already coincident with existing mesh features. I updated the baseline test's expected counts (documented inline why) rather than leaving it either broken or trivial. I judged this a natural test-maintenance consequence of correctly implementing the requested fix, not a product-behavior fork, so I didn't halt for it — but it's a deviation from the issue's literal text worth your review.
- All expected/hard-coded counts in the new tests were verified empirically against the actual running build (via a temporary, since-removed debug dump), not hand-derived — the underlying mesh-splitting math turned out too easy to get subtly wrong by hand.

**Review pass findings:** A background review agent independently rebuilt and re-verified my baseline counts (confirmed correct), and found two minor issues: (1) no test covered the edge-snap path — fixed in `0e5488d`; (2) the fixed 1.0-unit snap epsilon is scale-independent of the 128-unit grid — an inherent, documented tradeoff of the epsilon design rather than a bug, left as-is.

Please review the committed changes on the `issue-62` branch (worktree at `.worktrees/issue-62`) before deciding whether this is done or needs more work.

## Agent Verifications

**Phase 1**: Built the full solution (MSBuild, Debug|x86) after adding `GetTriangleCount`/`GetVertexCount`/`HasVertexNear` and the `NavmeshTestSuite` baseline regression test. Launched `TopDownGame.exe -hidewindow` and confirmed `NavmeshTestSuite::RunTests()` completes without an `FW_ASSERT` crash. The baseline test's hard-coded before/after triangle and vertex counts were determined empirically via a temporary, since-removed instrumented run rather than hand-derived, after an initial hand-derivation attempt proved to have been based on a flawed manual trace of the mesh-splitting math.

**Phase 2**: Built the full solution again after adding `EnsureCutterVerticesExist`, `InsertVertexInTriangle`, `SplitEdgeAtPosition`, `FindNearbyVertex`/`FindNearbyEdge`, and the `CollectCutEdges` degenerate-endpoint fix. Launched `TopDownGame.exe -hidewindow` and confirmed all `NavmeshTestSuite` cases pass (no crash), including the 3 new cases for: a cutter corner landing inside a triangle's interior, a cutter corner within epsilon of an existing vertex snapping instead of duplicating, and the updated Phase 1 baseline. A follow-up automatic review pass rebuilt and independently re-verified these results, and its one actionable finding (missing test coverage for the edge-snap path) was addressed with a 4th test case, also verified headlessly with a full passing run.

**Manual test**: Launched `TopDownGame.exe` interactively (menu → character-select → gameplay flow) and drew a box cut with the mouse; confirmed the resulting cut corners land precisely where clicked instead of drifting. User-reported: pass.
