### PR TITLE
TopDownGame: basic level-loading concept

### DIFF
--- a/Solution/TopDownGame/Level/Level.cpp
+++ b/Solution/TopDownGame/Level/Level.cpp
@@ -1,0 +1,26 @@
+#include "stdafx.h"
+
+#include "Level.h"
+#include <Core\Assets\AssetStorage.h>
+
+Level::Level()
+{
+	myLevelData = Slush::AssetRegistry::GetInstance().GetAsset<LevelData>("level_main");
+	FW_ASSERT(myLevelData, "Level has no valid LevelData - expected a 'level_main' LevelData asset");
+	FW_ASSERT(myLevelData->myNavmeshData.Get() != nullptr, "Level's LevelData has an unresolved NavmeshData reference");
+}
+
+Navmesh& Level::GetNavmesh()
+{
+	return myLevelData->myNavmeshData.Get()->myNavmesh;
+}
+
+void Level::Update()
+{
+	GetNavmesh().Update();
+}
+
+void Level::Render()
+{
+	GetNavmesh().Render();
+}

--- a/Solution/TopDownGame/Level/Level.h
+++ b/Solution/TopDownGame/Level/Level.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Core\Time.h>
+
+#include "LevelData.h"
+
+class Level
+{
+public:
+	Level();
+
+	Navmesh& GetNavmesh();
+
+	void Update();
+	void Render();
+
+private:
+	LevelData* myLevelData = nullptr;
+
+	int myCurrentWaveIndex = 0;
+	Slush::Timer myNextWaveTimer;
+};

--- a/Solution/TopDownGame/Level/LevelData.cpp
+++ b/Solution/TopDownGame/Level/LevelData.cpp
@@ -1,0 +1,51 @@
+#include "stdafx.h"
+
+#include "LevelData.h"
+#include <imgui\ImGuiWidgets.h>
+
+LevelData::LevelData(const char* aName, unsigned int aAssetID)
+	: DataAsset(aName, aAssetID)
+{
+}
+
+void LevelData::OnParse(Slush::AssetParser::Handle aRootHandle, unsigned int /*aVersion*/)
+{
+	if (aRootHandle.IsReading())
+		OnLoad(aRootHandle);
+	else
+		OnSave(aRootHandle);
+}
+
+void LevelData::ResolveDependencies()
+{
+	myNavmeshData.ResolveDependency();
+}
+
+void LevelData::BuildUI()
+{
+	Slush::ImGuiWidgets::InputFloat2("Start Position", &myStartPosition.x);
+	Slush::ImGuiWidgets::InputFloat2("Goal Position", &myGoalPosition.x);
+
+	ImGui::Text("Navmesh: %s", myNavmeshData.GetName().GetBuffer());
+	if (ImGui::BeginDragDropTarget())
+	{
+		if (Slush::Asset* asset = ImGui::AcceptDraggedAsset(Slush::GetAssetID<NavmeshData>()))
+			myNavmeshData.Set(static_cast<NavmeshData*>(asset));
+
+		ImGui::EndDragDropTarget();
+	}
+}
+
+void LevelData::OnLoad(Slush::AssetParser::Handle aRootHandle)
+{
+	aRootHandle.ParseVec2fField("startPosition", myStartPosition);
+	aRootHandle.ParseVec2fField("goalPosition", myGoalPosition);
+	myNavmeshData.Parse(aRootHandle, "navmeshData");
+}
+
+void LevelData::OnSave(Slush::AssetParser::Handle aRootHandle)
+{
+	aRootHandle.ParseVec2fField("startPosition", myStartPosition);
+	aRootHandle.ParseVec2fField("goalPosition", myGoalPosition);
+	myNavmeshData.Parse(aRootHandle, "navmeshData");
+}

--- a/Solution/TopDownGame/Level/LevelData.h
+++ b/Solution/TopDownGame/Level/LevelData.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <Core\Assets\DataAsset.h>
+#include <Core\Assets\AssetReference.h>
+
+#include "NavmeshData.h"
+
+class LevelData : public Slush::DataAsset
+{
+public:
+	DEFINE_ASSET("LevelData", "tdlevel", "data/levels/", ICON_FA_MAP, 1);
+
+	LevelData(const char* aName, unsigned int aAssetID);
+
+	void OnParse(Slush::AssetParser::Handle aRootHandle, unsigned int aVersion) override;
+	void ResolveDependencies() override;
+	void BuildUI() override;
+
+	Vector2f myStartPosition;
+	Vector2f myGoalPosition;
+	Slush::AssetReference<NavmeshData> myNavmeshData;
+
+private:
+	void OnLoad(Slush::AssetParser::Handle aRootHandle);
+	void OnSave(Slush::AssetParser::Handle aRootHandle);
+};

--- a/Solution/TopDownGame/Level/NavmeshData.cpp
+++ b/Solution/TopDownGame/Level/NavmeshData.cpp
@@ -1,0 +1,16 @@
+#include "stdafx.h"
+
+#include "NavmeshData.h"
+
+NavmeshData::NavmeshData(const char* aName, unsigned int aAssetID)
+	: DataAsset(aName, aAssetID)
+{
+}
+
+void NavmeshData::OnParse(Slush::AssetParser::Handle aRootHandle, unsigned int /*aVersion*/)
+{
+	if (aRootHandle.IsReading())
+		myNavmesh.Load(aRootHandle);
+	else
+		myNavmesh.Save(aRootHandle);
+}

--- a/Solution/TopDownGame/Level/NavmeshData.h
+++ b/Solution/TopDownGame/Level/NavmeshData.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <Core\Assets\DataAsset.h>
+
+#include "../Navmesh.h"
+
+class NavmeshData : public Slush::DataAsset
+{
+public:
+	DEFINE_ASSET("NavmeshData", "navmesh", "data/navmeshes/", ICON_FA_DRAW_POLYGON, 1);
+
+	NavmeshData(const char* aName, unsigned int aAssetID);
+
+	void OnParse(Slush::AssetParser::Handle aRootHandle, unsigned int aVersion) override;
+
+	Navmesh myNavmesh;
+};

--- a/Solution/TopDownGame/Navmesh.cpp
+++ b/Solution/TopDownGame/Navmesh.cpp
@@ -8,6 +8,17 @@
 
 Navmesh::Navmesh()
 {
+}
+
+Navmesh::~Navmesh()
+{
+	myTriangles.DeleteAll();
+	myEdges.DeleteAll();
+	myVertices.DeleteAll();
+}
+
+void Navmesh::GenerateDefaultGrid()
+{
 	Vector2f offset = { 20.f, 20. };
 	Vertex* topLeft = CreateVertex(offset);
 
@@ -26,13 +37,6 @@ Navmesh::Navmesh()
 		topLeft = bottomEdges[0]->myVertices[0];
 		outRight = nullptr;
 	}
-}
-
-Navmesh::~Navmesh()
-{
-	myTriangles.DeleteAll();
-	myEdges.DeleteAll();
-	myVertices.DeleteAll();
 }
 
 void Navmesh::Update()

--- a/Solution/TopDownGame/Navmesh.cpp
+++ b/Solution/TopDownGame/Navmesh.cpp
@@ -39,6 +39,72 @@ void Navmesh::GenerateDefaultGrid()
 	}
 }
 
+void Navmesh::Save(Slush::AssetParser::Handle aRootHandle) const
+{
+	// Edges are never stored directly - an edge is always exactly "the edge shared by two
+	// triangles" (or unshared, on the mesh boundary) and gets reconstructed from the triangle
+	// list on Load(), via FindOrCreateEdge().
+	Slush::AssetParser::Handle verticesHandle = aRootHandle.ParseChildElement("vertices");
+	for (Vertex* vertex : myVertices)
+	{
+		Slush::AssetParser::Handle vertexHandle = verticesHandle.ParseChildElement("vertex");
+		vertexHandle.ParseVec2fField("pos", vertex->myPos);
+	}
+
+	Slush::AssetParser::Handle trianglesHandle = aRootHandle.ParseChildElement("triangles");
+	for (Triangle* triangle : myTriangles)
+	{
+		Slush::AssetParser::Handle triangleHandle = trianglesHandle.ParseChildElement("triangle");
+		int indices[3];
+		for (int i = 0; i < 3; ++i)
+			indices[i] = myVertices.Find(triangle->myVertices[i]);
+
+		triangleHandle.ParseIntField("v0", indices[0]);
+		triangleHandle.ParseIntField("v1", indices[1]);
+		triangleHandle.ParseIntField("v2", indices[2]);
+	}
+}
+
+void Navmesh::Load(Slush::AssetParser::Handle aRootHandle)
+{
+	myTriangles.DeleteAll();
+	myEdges.DeleteAll();
+	myVertices.DeleteAll();
+
+	Slush::AssetParser::Handle verticesHandle = aRootHandle.ParseChildElement("vertices");
+	int numVertices = verticesHandle.GetNumChildElements();
+	FW_GrowingArray<Vertex*> loadedVertices;
+	loadedVertices.Reserve(numVertices);
+	for (int i = 0; i < numVertices; ++i)
+	{
+		Slush::AssetParser::Handle vertexHandle = verticesHandle.GetChildElementAtIndex(i);
+		Vector2f pos;
+		vertexHandle.ParseVec2fField("pos", pos);
+		loadedVertices[i] = CreateVertex(pos);
+	}
+
+	Slush::AssetParser::Handle trianglesHandle = aRootHandle.ParseChildElement("triangles");
+	int numTriangles = trianglesHandle.GetNumChildElements();
+	for (int i = 0; i < numTriangles; ++i)
+	{
+		Slush::AssetParser::Handle triangleHandle = trianglesHandle.GetChildElementAtIndex(i);
+		int indices[3] = {};
+		triangleHandle.ParseIntField("v0", indices[0]);
+		triangleHandle.ParseIntField("v1", indices[1]);
+		triangleHandle.ParseIntField("v2", indices[2]);
+
+		Vertex* v0 = loadedVertices[indices[0]];
+		Vertex* v1 = loadedVertices[indices[1]];
+		Vertex* v2 = loadedVertices[indices[2]];
+
+		Edge* e0 = FindOrCreateEdge(v0, v1);
+		Edge* e1 = FindOrCreateEdge(v1, v2);
+		Edge* e2 = FindOrCreateEdge(v2, v0);
+
+		CreateTriangle(e0, e1, e2);
+	}
+}
+
 void Navmesh::Update()
 {
 	Slush::Engine& engine = Slush::Engine::GetInstance();
@@ -549,6 +615,18 @@ Navmesh::Edge* Navmesh::CreateEdge(Vertex* aV1, Vertex* aV2)
 	aV2->myEdges.Add(edge);
 	myEdges.Add(edge);
 	return edge;
+}
+
+Navmesh::Edge* Navmesh::FindOrCreateEdge(Vertex* aV1, Vertex* aV2)
+{
+	for (Edge* edge : aV1->myEdges)
+	{
+		if ((edge->myVertices[0] == aV1 && edge->myVertices[1] == aV2) ||
+			(edge->myVertices[0] == aV2 && edge->myVertices[1] == aV1))
+			return edge;
+	}
+
+	return CreateEdge(aV1, aV2);
 }
 
 void Navmesh::DeleteEdgeIfNeeded(Edge* aEdge)

--- a/Solution/TopDownGame/Navmesh.h
+++ b/Solution/TopDownGame/Navmesh.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "FW_Intersection.h"
+#include <Core\Assets\AssetParser.h>
 
 class Navmesh
 {
@@ -8,6 +9,9 @@ public:
 	~Navmesh();
 
 	void GenerateDefaultGrid();
+
+	void Save(Slush::AssetParser::Handle aRootHandle) const;
+	void Load(Slush::AssetParser::Handle aRootHandle);
 
 	void Update();
 	void Render();
@@ -101,6 +105,7 @@ private:
 	void DeleteVertexIfNeeded(Vertex* aVertex);
 
 	Edge* CreateEdge(Vertex* aV1, Vertex* aV2);
+	Edge* FindOrCreateEdge(Vertex* aV1, Vertex* aV2);
 	void DeleteEdgeIfNeeded(Edge* aEdge);
 
 	Triangle* CreateTriangle(Edge* aE1, Edge* aE2, Edge* aE3);

--- a/Solution/TopDownGame/Navmesh.h
+++ b/Solution/TopDownGame/Navmesh.h
@@ -7,6 +7,8 @@ public:
 	Navmesh();
 	~Navmesh();
 
+	void GenerateDefaultGrid();
+
 	void Update();
 	void Render();
 

--- a/Solution/TopDownGame/NavmeshTestSuite.cpp
+++ b/Solution/TopDownGame/NavmeshTestSuite.cpp
@@ -3,7 +3,6 @@
 #include "NavmeshTestSuite.h"
 #include "Navmesh.h"
 #include "Level/NavmeshData.h"
-#include <FW_FileSystem.h>
 
 namespace NavmeshTestSuite
 {
@@ -248,8 +247,6 @@ namespace NavmeshTestSuite
 
 	void TestNavmeshSaveLoadRoundTrip()
 	{
-		FW_FileSystem::CreateFolderIfNecessary(NavmeshData::GetAssetTypeFolder());
-
 		NavmeshData original("navmesh_roundtrip_test", 0);
 		original.myNavmesh.GenerateDefaultGrid();
 
@@ -267,18 +264,25 @@ namespace NavmeshTestSuite
 		cutBlockB.Add(Vector2f{ 900.f, 400.f });
 		original.myNavmesh.CutHole(cutBlockB);
 
-		original.Save();
+		// Drive NavmeshData::OnParse() directly (bypassing DataAsset::Save()/Load()'s
+		// folder-derived paths) so this test writes to its own scratch file under temp/ instead
+		// of the real data/navmeshes/ folder - that folder is scanned by AssetStorage<NavmeshData>
+		// on every launch, so writing there would leave this fixture behind as a permanent, visible
+		// asset in the editor UI, not just a test artifact.
+		// "temp/" already exists (FW_UnitTestSuite's own file-processor test lives there) -
+		// CreateFolderIfNecessary() can't be used here anyway, since it assumes every path
+		// contains a "data" segment.
+		const char* testFilePath = "temp/navmesh_roundtrip_test.navmesh";
 
-		// DataAsset::Save() doesn't populate myFilePath (only Load() does) - build the same
-		// path Save() just wrote to, so Load() below can read it back.
-		FW_String filePath = NavmeshData::GetAssetTypeFolder();
-		filePath += "/";
-		filePath += original.GetAssetName();
-		filePath += ".";
-		filePath += NavmeshData::GetAssetTypeExtention();
+		Slush::AssetParser writer;
+		Slush::AssetParser::Handle writeHandle = writer.StartWriting("NavmeshData");
+		original.OnParse(writeHandle, 1);
+		writer.FinishWriting(testFilePath);
 
+		Slush::AssetParser reader;
+		Slush::AssetParser::Handle readHandle = reader.Load(testFilePath);
 		NavmeshData loaded("navmesh_roundtrip_test", 0);
-		loaded.Load(filePath.GetBuffer());
+		loaded.OnParse(readHandle, 1);
 
 		FW_ASSERT(loaded.myNavmesh.GetVertexCount() == original.myNavmesh.GetVertexCount(), "Expected matching vertex counts after a save/load round-trip");
 		FW_ASSERT(loaded.myNavmesh.GetTriangleCount() == original.myNavmesh.GetTriangleCount(), "Expected matching triangle counts after a save/load round-trip");
@@ -296,8 +300,13 @@ namespace NavmeshTestSuite
 
 		FW_ASSERT(originalFound && loadedFound, "Expected FindPath to succeed on both the original and the round-tripped navmesh");
 		FW_ASSERT(loadedWaypoints.Count() == originalWaypoints.Count(), "Expected matching waypoint counts after a save/load round-trip");
+
+		// Epsilon compare, not ==: field values round-trip through AssetParser's "%.3f" float
+		// formatting, so a waypoint landing on a non-exact-decimal position would otherwise make
+		// this fail on a correct round-trip purely from serialization precision loss.
+		const float PositionEpsilon = 0.01f;
 		for (int i = 0; i < originalWaypoints.Count(); ++i)
-			FW_ASSERT(loadedWaypoints[i] == originalWaypoints[i], "Expected matching waypoints after a save/load round-trip");
+			FW_ASSERT(Length2(loadedWaypoints[i] - originalWaypoints[i]) <= PositionEpsilon * PositionEpsilon, "Expected matching waypoints after a save/load round-trip");
 	}
 
 	void RunTests()

--- a/Solution/TopDownGame/NavmeshTestSuite.cpp
+++ b/Solution/TopDownGame/NavmeshTestSuite.cpp
@@ -2,6 +2,8 @@
 
 #include "NavmeshTestSuite.h"
 #include "Navmesh.h"
+#include "Level/NavmeshData.h"
+#include <FW_FileSystem.h>
 
 namespace NavmeshTestSuite
 {
@@ -244,8 +246,63 @@ namespace NavmeshTestSuite
 		FW_ASSERT(mesh.HasVertexNear(cornerNearEdge, 0.01f), "Expected a vertex snapped onto the nearby edge at the cutter's own corner position");
 	}
 
+	void TestNavmeshSaveLoadRoundTrip()
+	{
+		FW_FileSystem::CreateFolderIfNecessary(NavmeshData::GetAssetTypeFolder());
+
+		NavmeshData original("navmesh_roundtrip_test", 0);
+		original.myNavmesh.GenerateDefaultGrid();
+
+		FW_GrowingArray<Vector2f> cutBlockA;
+		cutBlockA.Add(Vector2f{ 100.f, 100.f });
+		cutBlockA.Add(Vector2f{ 200.f, 100.f });
+		cutBlockA.Add(Vector2f{ 200.f, 200.f });
+		cutBlockA.Add(Vector2f{ 100.f, 200.f });
+		original.myNavmesh.CutHole(cutBlockA);
+
+		FW_GrowingArray<Vector2f> cutBlockB;
+		cutBlockB.Add(Vector2f{ 900.f, 300.f });
+		cutBlockB.Add(Vector2f{ 1000.f, 300.f });
+		cutBlockB.Add(Vector2f{ 1000.f, 400.f });
+		cutBlockB.Add(Vector2f{ 900.f, 400.f });
+		original.myNavmesh.CutHole(cutBlockB);
+
+		original.Save();
+
+		// DataAsset::Save() doesn't populate myFilePath (only Load() does) - build the same
+		// path Save() just wrote to, so Load() below can read it back.
+		FW_String filePath = NavmeshData::GetAssetTypeFolder();
+		filePath += "/";
+		filePath += original.GetAssetName();
+		filePath += ".";
+		filePath += NavmeshData::GetAssetTypeExtention();
+
+		NavmeshData loaded("navmesh_roundtrip_test", 0);
+		loaded.Load(filePath.GetBuffer());
+
+		FW_ASSERT(loaded.myNavmesh.GetVertexCount() == original.myNavmesh.GetVertexCount(), "Expected matching vertex counts after a save/load round-trip");
+		FW_ASSERT(loaded.myNavmesh.GetTriangleCount() == original.myNavmesh.GetTriangleCount(), "Expected matching triangle counts after a save/load round-trip");
+
+		Vector2f start{ 50.f, 50.f };
+		Vector2f goal{ 1900.f, 850.f };
+
+		FW_GrowingArray<Vector2f> originalWaypoints;
+		Navmesh::PathCorridor originalCorridor;
+		bool originalFound = original.myNavmesh.FindPath(start, goal, originalWaypoints, originalCorridor);
+
+		FW_GrowingArray<Vector2f> loadedWaypoints;
+		Navmesh::PathCorridor loadedCorridor;
+		bool loadedFound = loaded.myNavmesh.FindPath(start, goal, loadedWaypoints, loadedCorridor);
+
+		FW_ASSERT(originalFound && loadedFound, "Expected FindPath to succeed on both the original and the round-tripped navmesh");
+		FW_ASSERT(loadedWaypoints.Count() == originalWaypoints.Count(), "Expected matching waypoint counts after a save/load round-trip");
+		for (int i = 0; i < originalWaypoints.Count(); ++i)
+			FW_ASSERT(loadedWaypoints[i] == originalWaypoints[i], "Expected matching waypoints after a save/load round-trip");
+	}
+
 	void RunTests()
 	{
+		TestNavmeshSaveLoadRoundTrip();
 		TestCutAcrossOneQuadProducesExpectedCounts();
 		TestCutterCornerInsideTriangleInteriorProducesVertexThere();
 		TestCutterCornerNearExistingVertexSnapsInsteadOfDuplicating();

--- a/Solution/TopDownGame/NavmeshTestSuite.cpp
+++ b/Solution/TopDownGame/NavmeshTestSuite.cpp
@@ -17,6 +17,7 @@ namespace NavmeshTestSuite
 	void TestFindPathSucceedsBetweenReachablePoints()
 	{
 		Navmesh mesh;
+		mesh.GenerateDefaultGrid();
 
 		Vector2f start{ 50.f, 50.f };
 		Vector2f goal{ 1900.f, 850.f };
@@ -34,6 +35,7 @@ namespace NavmeshTestSuite
 	void TestFindPathFailsOutsideMesh()
 	{
 		Navmesh mesh;
+		mesh.GenerateDefaultGrid();
 
 		Vector2f start{ -100.f, -100.f };
 		Vector2f goal{ 50.f, 50.f };
@@ -49,6 +51,7 @@ namespace NavmeshTestSuite
 	void TestFindPathFailsWhenCutDisconnectsStartFromGoal()
 	{
 		Navmesh mesh;
+		mesh.GenerateDefaultGrid();
 
 		// A horizontal band spanning wider than the mesh, cutting it into a top half and a bottom half.
 		FW_GrowingArray<Vector2f> cutBand;
@@ -71,6 +74,7 @@ namespace NavmeshTestSuite
 	void TestFindPathSameTriangleYieldsStraightPath()
 	{
 		Navmesh mesh;
+		mesh.GenerateDefaultGrid();
 
 		Vector2f start{ 30.f, 30.f };
 		Vector2f goal{ 40.f, 35.f };
@@ -89,6 +93,7 @@ namespace NavmeshTestSuite
 	void TestStringPullIsNoLongerThanEdgeCenterPath()
 	{
 		Navmesh mesh;
+		mesh.GenerateDefaultGrid();
 
 		// A block that leaves room above and below, so the corridor between start and goal
 		// has to bend around it rather than running straight through.
@@ -119,6 +124,7 @@ namespace NavmeshTestSuite
 	void TestStringPullCanReFunnelAnExistingCorridorFromANewStart()
 	{
 		Navmesh mesh;
+		mesh.GenerateDefaultGrid();
 
 		FW_GrowingArray<Vector2f> cutBlock;
 		cutBlock.Add(Vector2f{ 860.f, 300.f });
@@ -151,6 +157,7 @@ namespace NavmeshTestSuite
 	void TestCutAcrossOneQuadProducesExpectedCounts()
 	{
 		Navmesh mesh;
+		mesh.GenerateDefaultGrid();
 
 		const int initialTriangleCount = mesh.GetTriangleCount();
 		const int initialVertexCount = mesh.GetVertexCount();
@@ -178,6 +185,7 @@ namespace NavmeshTestSuite
 	void TestCutterCornerInsideTriangleInteriorProducesVertexThere()
 	{
 		Navmesh mesh;
+		mesh.GenerateDefaultGrid();
 
 		Vector2f cornerDeepInsideATriangle{ 45.f, 45.f };
 		FW_ASSERT(!mesh.HasVertexNear(cornerDeepInsideATriangle, 0.01f), "Test setup: expected no existing vertex at this position");
@@ -194,6 +202,7 @@ namespace NavmeshTestSuite
 	void TestCutterCornerNearExistingVertexSnapsInsteadOfDuplicating()
 	{
 		Navmesh mesh;
+		mesh.GenerateDefaultGrid();
 
 		// The exact 3 vertices of one interior quad's own upper-left triangle - already real navmesh
 		// vertices, so EnsureCutterVerticesExist should snap to each rather than inserting a
@@ -218,6 +227,7 @@ namespace NavmeshTestSuite
 	void TestCutterCornerNearExistingEdgeSnapsOntoThatEdge()
 	{
 		Navmesh mesh;
+		mesh.GenerateDefaultGrid();
 
 		// A point close to (but not exactly on, and well clear of either endpoint of) one interior
 		// quad's own top edge - should snap onto that edge via SplitEdgeAtPosition rather than

--- a/Solution/TopDownGame/TopDownGame.vcxproj
+++ b/Solution/TopDownGame/TopDownGame.vcxproj
@@ -146,6 +146,7 @@
     <ClCompile Include="NavmeshTestSuite.cpp" />
     <ClCompile Include="Level\NavmeshData.cpp" />
     <ClCompile Include="Level\LevelData.cpp" />
+    <ClCompile Include="Level\Level.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
@@ -157,6 +158,7 @@
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="Level\NavmeshData.h" />
     <ClInclude Include="Level\LevelData.h" />
+    <ClInclude Include="Level\Level.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Solution/TopDownGame/TopDownGame.vcxproj
+++ b/Solution/TopDownGame/TopDownGame.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="Navmesh.cpp" />
     <ClCompile Include="NavmeshTestSuite.cpp" />
     <ClCompile Include="Level\NavmeshData.cpp" />
+    <ClCompile Include="Level\LevelData.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
@@ -155,6 +156,7 @@
     <ClInclude Include="NavmeshTestSuite.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="Level\NavmeshData.h" />
+    <ClInclude Include="Level\LevelData.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Solution/TopDownGame/TopDownGame.vcxproj
+++ b/Solution/TopDownGame/TopDownGame.vcxproj
@@ -73,12 +73,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(RepoRoot)Workbed\$(ProjectName)\</OutDir>
     <IntDir>$(RepoRoot)Build_Output\$(ProjectName)\$(Configuration)\</IntDir>
-    <IncludePath>$(SolutionDir)\Engine;$(SolutionDir)..\SFML\include;$(SolutionDir)\Framework;$(SolutionDir)\ActionGame;$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)\Engine;$(SolutionDir)..\SFML\include;$(SolutionDir)\Framework;$(SolutionDir)\ActionGame;$(SolutionDir)\TopDownGame;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(RepoRoot)Workbed\$(ProjectName)\</OutDir>
     <IntDir>$(RepoRoot)Build_Output\$(ProjectName)\$(Configuration)\</IntDir>
-    <IncludePath>$(SolutionDir)\Engine;$(SolutionDir)..\SFML\include;$(SolutionDir)\Framework;$(SolutionDir)\ActionGame;$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)\Engine;$(SolutionDir)..\SFML\include;$(SolutionDir)\Framework;$(SolutionDir)\ActionGame;$(SolutionDir)\TopDownGame;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -144,6 +144,7 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Navmesh.cpp" />
     <ClCompile Include="NavmeshTestSuite.cpp" />
+    <ClCompile Include="Level\NavmeshData.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
@@ -153,6 +154,7 @@
     <ClInclude Include="Navmesh.h" />
     <ClInclude Include="NavmeshTestSuite.h" />
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="Level\NavmeshData.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Solution/TopDownGame/TopDownGame.vcxproj.filters
+++ b/Solution/TopDownGame/TopDownGame.vcxproj.filters
@@ -7,6 +7,7 @@
     <ClCompile Include="NavmeshTestSuite.cpp" />
     <ClCompile Include="Level\NavmeshData.cpp" />
     <ClCompile Include="Level\LevelData.cpp" />
+    <ClCompile Include="Level\Level.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -14,5 +15,6 @@
     <ClInclude Include="NavmeshTestSuite.h" />
     <ClInclude Include="Level\NavmeshData.h" />
     <ClInclude Include="Level\LevelData.h" />
+    <ClInclude Include="Level\Level.h" />
   </ItemGroup>
 </Project>

--- a/Solution/TopDownGame/TopDownGame.vcxproj.filters
+++ b/Solution/TopDownGame/TopDownGame.vcxproj.filters
@@ -5,10 +5,12 @@
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="Navmesh.cpp" />
     <ClCompile Include="NavmeshTestSuite.cpp" />
+    <ClCompile Include="Level\NavmeshData.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="Navmesh.h" />
     <ClInclude Include="NavmeshTestSuite.h" />
+    <ClInclude Include="Level\NavmeshData.h" />
   </ItemGroup>
 </Project>

--- a/Solution/TopDownGame/TopDownGame.vcxproj.filters
+++ b/Solution/TopDownGame/TopDownGame.vcxproj.filters
@@ -6,11 +6,13 @@
     <ClCompile Include="Navmesh.cpp" />
     <ClCompile Include="NavmeshTestSuite.cpp" />
     <ClCompile Include="Level\NavmeshData.cpp" />
+    <ClCompile Include="Level\LevelData.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="Navmesh.h" />
     <ClInclude Include="NavmeshTestSuite.h" />
     <ClInclude Include="Level\NavmeshData.h" />
+    <ClInclude Include="Level\LevelData.h" />
   </ItemGroup>
 </Project>

--- a/Solution/TopDownGame/main.cpp
+++ b/Solution/TopDownGame/main.cpp
@@ -9,6 +9,7 @@
 #include "Graphics/Renderer.h"
 #include "Core/Input.h"
 
+#include "Level/Level.h"
 #include "Level/LevelData.h"
 #include "Level/NavmeshData.h"
 #include "Navmesh.h"
@@ -28,11 +29,12 @@ public:
 		window.ToggleEditorUI();
 		window.SetAppLayout(new Slush::AssetEditorLayout());
 
-		myNavmesh.GenerateDefaultGrid();
+		myLevel = new Level();
 	}
 
 	void Shutdown() override
 	{
+		FW_SAFE_DELETE(myLevel);
 	}
 
 	void Update() override
@@ -42,7 +44,7 @@ public:
 		if (engine.GetInput().WasKeyReleased(Slush::Input::ESC))
 			engine.GetWindow().Close();
 
-		myNavmesh.Update();
+		myLevel->Update();
 	}
 
 	void Render() override
@@ -50,13 +52,13 @@ public:
 		Slush::Renderer& renderer = Slush::Engine::GetInstance().GetWindow().GetRenderer();
 		renderer.StartOffscreenBuffer();
 
-		myNavmesh.Render();
+		myLevel->Render();
 
 		renderer.EndOffscreenBuffer();
 	}
 
 private:
-	Navmesh myNavmesh;
+	Level* myLevel = nullptr;
 };
 
 #include <FW_UnitTestSuite.h>

--- a/Solution/TopDownGame/main.cpp
+++ b/Solution/TopDownGame/main.cpp
@@ -17,7 +17,8 @@ public:
 	{
 		Slush::Window& window = Slush::Engine::GetInstance().GetWindow();
 		window.ToggleEditorUI();
-		
+
+		myNavmesh.GenerateDefaultGrid();
 	}
 
 	void Shutdown() override

--- a/Solution/TopDownGame/main.cpp
+++ b/Solution/TopDownGame/main.cpp
@@ -1,12 +1,15 @@
 #include "stdafx.h"
 
 #include "Core/IApp.h"
+#include "Core/Assets/AssetStorage.h"
 #include "Core/CommandLineArgs.h"
+#include "Core/Dockables/AssetEditorLayout.h"
 #include "Core/Engine.h"
 #include "Graphics/Window.h"
 #include "Graphics/Renderer.h"
 #include "Core/Input.h"
 
+#include "Level/NavmeshData.h"
 #include "Navmesh.h"
 #include "NavmeshTestSuite.h"
 
@@ -15,8 +18,13 @@ class App : public Slush::IApp
 public:
 	void Initialize() override
 	{
+		Slush::AssetRegistry& assets = Slush::AssetRegistry::GetInstance();
+		assets.RegisterAssetType<NavmeshData>();
+		assets.LoadAllAssets();
+
 		Slush::Window& window = Slush::Engine::GetInstance().GetWindow();
 		window.ToggleEditorUI();
+		window.SetAppLayout(new Slush::AssetEditorLayout());
 
 		myNavmesh.GenerateDefaultGrid();
 	}

--- a/Solution/TopDownGame/main.cpp
+++ b/Solution/TopDownGame/main.cpp
@@ -9,6 +9,7 @@
 #include "Graphics/Renderer.h"
 #include "Core/Input.h"
 
+#include "Level/LevelData.h"
 #include "Level/NavmeshData.h"
 #include "Navmesh.h"
 #include "NavmeshTestSuite.h"
@@ -20,6 +21,7 @@ public:
 	{
 		Slush::AssetRegistry& assets = Slush::AssetRegistry::GetInstance();
 		assets.RegisterAssetType<NavmeshData>();
+		assets.RegisterAssetType<LevelData>();
 		assets.LoadAllAssets();
 
 		Slush::Window& window = Slush::Engine::GetInstance().GetWindow();

--- a/Workbed/TopDownGame/Data/levels/level_main.tdlevel
+++ b/Workbed/TopDownGame/Data/levels/level_main.tdlevel
@@ -1,0 +1,15 @@
+LevelData 
+{ 
+	version 1 
+	navmeshData navmesh_main 
+	startPosition 
+	{ 
+		x 50.000 
+		y 50.000 
+	} 
+	goalPosition 
+	{ 
+		x 1900.000 
+		y 850.000 
+	} 
+} 

--- a/Workbed/TopDownGame/Data/navmeshes/navmesh_main.navmesh
+++ b/Workbed/TopDownGame/Data/navmeshes/navmesh_main.navmesh
@@ -1,0 +1,2562 @@
+NavmeshData 
+{ 
+	version 1 
+	vertices 
+	{ 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 860.000 
+				y 332.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 860.000 
+				y 588.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 860.000 
+				y 345.500 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 860.000 
+				y 460.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 860.000 
+				y 300.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1100.000 
+				y 300.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1100.000 
+				y 636.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 860.000 
+				y 636.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 300.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 892.000 
+				y 300.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 300.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1020.000 
+				y 300.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1100.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1100.000 
+				y 348.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1100.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1100.000 
+				y 476.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1100.000 
+				y 604.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1068.000 
+				y 636.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 636.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 636.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 940.000 
+				y 636.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1054.500 
+				y 636.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 860.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 860.000 
+				y 532.000 
+			} 
+		} 
+	} 
+	triangles 
+	{ 
+		triangle 
+		{ 
+			v0 0 
+			v1 1 
+			v2 2 
+		} 
+		triangle 
+		{ 
+			v0 2 
+			v1 3 
+			v2 1 
+		} 
+		triangle 
+		{ 
+			v0 2 
+			v1 3 
+			v2 4 
+		} 
+		triangle 
+		{ 
+			v0 4 
+			v1 5 
+			v2 3 
+		} 
+		triangle 
+		{ 
+			v0 4 
+			v1 5 
+			v2 6 
+		} 
+		triangle 
+		{ 
+			v0 6 
+			v1 7 
+			v2 5 
+		} 
+		triangle 
+		{ 
+			v0 6 
+			v1 7 
+			v2 8 
+		} 
+		triangle 
+		{ 
+			v0 8 
+			v1 9 
+			v2 7 
+		} 
+		triangle 
+		{ 
+			v0 8 
+			v1 9 
+			v2 10 
+		} 
+		triangle 
+		{ 
+			v0 10 
+			v1 11 
+			v2 9 
+		} 
+		triangle 
+		{ 
+			v0 10 
+			v1 11 
+			v2 12 
+		} 
+		triangle 
+		{ 
+			v0 12 
+			v1 13 
+			v2 11 
+		} 
+		triangle 
+		{ 
+			v0 12 
+			v1 13 
+			v2 14 
+		} 
+		triangle 
+		{ 
+			v0 14 
+			v1 15 
+			v2 13 
+		} 
+		triangle 
+		{ 
+			v0 14 
+			v1 15 
+			v2 16 
+		} 
+		triangle 
+		{ 
+			v0 16 
+			v1 17 
+			v2 15 
+		} 
+		triangle 
+		{ 
+			v0 16 
+			v1 17 
+			v2 18 
+		} 
+		triangle 
+		{ 
+			v0 18 
+			v1 19 
+			v2 17 
+		} 
+		triangle 
+		{ 
+			v0 18 
+			v1 19 
+			v2 20 
+		} 
+		triangle 
+		{ 
+			v0 20 
+			v1 21 
+			v2 19 
+		} 
+		triangle 
+		{ 
+			v0 20 
+			v1 21 
+			v2 22 
+		} 
+		triangle 
+		{ 
+			v0 22 
+			v1 23 
+			v2 21 
+		} 
+		triangle 
+		{ 
+			v0 22 
+			v1 23 
+			v2 24 
+		} 
+		triangle 
+		{ 
+			v0 24 
+			v1 25 
+			v2 23 
+		} 
+		triangle 
+		{ 
+			v0 24 
+			v1 25 
+			v2 26 
+		} 
+		triangle 
+		{ 
+			v0 26 
+			v1 27 
+			v2 25 
+		} 
+		triangle 
+		{ 
+			v0 26 
+			v1 27 
+			v2 28 
+		} 
+		triangle 
+		{ 
+			v0 28 
+			v1 29 
+			v2 27 
+		} 
+		triangle 
+		{ 
+			v0 28 
+			v1 29 
+			v2 30 
+		} 
+		triangle 
+		{ 
+			v0 30 
+			v1 31 
+			v2 29 
+		} 
+		triangle 
+		{ 
+			v0 1 
+			v1 32 
+			v2 3 
+		} 
+		triangle 
+		{ 
+			v0 3 
+			v1 33 
+			v2 32 
+		} 
+		triangle 
+		{ 
+			v0 3 
+			v1 33 
+			v2 5 
+		} 
+		triangle 
+		{ 
+			v0 5 
+			v1 34 
+			v2 33 
+		} 
+		triangle 
+		{ 
+			v0 5 
+			v1 34 
+			v2 7 
+		} 
+		triangle 
+		{ 
+			v0 7 
+			v1 35 
+			v2 34 
+		} 
+		triangle 
+		{ 
+			v0 7 
+			v1 35 
+			v2 9 
+		} 
+		triangle 
+		{ 
+			v0 9 
+			v1 36 
+			v2 35 
+		} 
+		triangle 
+		{ 
+			v0 9 
+			v1 36 
+			v2 11 
+		} 
+		triangle 
+		{ 
+			v0 11 
+			v1 37 
+			v2 36 
+		} 
+		triangle 
+		{ 
+			v0 11 
+			v1 37 
+			v2 13 
+		} 
+		triangle 
+		{ 
+			v0 13 
+			v1 38 
+			v2 37 
+		} 
+		triangle 
+		{ 
+			v0 13 
+			v1 38 
+			v2 15 
+		} 
+		triangle 
+		{ 
+			v0 15 
+			v1 39 
+			v2 38 
+		} 
+		triangle 
+		{ 
+			v0 15 
+			v1 39 
+			v2 17 
+		} 
+		triangle 
+		{ 
+			v0 17 
+			v1 40 
+			v2 39 
+		} 
+		triangle 
+		{ 
+			v0 17 
+			v1 40 
+			v2 19 
+		} 
+		triangle 
+		{ 
+			v0 19 
+			v1 41 
+			v2 40 
+		} 
+		triangle 
+		{ 
+			v0 19 
+			v1 41 
+			v2 21 
+		} 
+		triangle 
+		{ 
+			v0 21 
+			v1 42 
+			v2 41 
+		} 
+		triangle 
+		{ 
+			v0 21 
+			v1 42 
+			v2 23 
+		} 
+		triangle 
+		{ 
+			v0 23 
+			v1 43 
+			v2 42 
+		} 
+		triangle 
+		{ 
+			v0 23 
+			v1 43 
+			v2 25 
+		} 
+		triangle 
+		{ 
+			v0 25 
+			v1 44 
+			v2 43 
+		} 
+		triangle 
+		{ 
+			v0 25 
+			v1 44 
+			v2 27 
+		} 
+		triangle 
+		{ 
+			v0 27 
+			v1 45 
+			v2 44 
+		} 
+		triangle 
+		{ 
+			v0 27 
+			v1 45 
+			v2 29 
+		} 
+		triangle 
+		{ 
+			v0 29 
+			v1 46 
+			v2 45 
+		} 
+		triangle 
+		{ 
+			v0 29 
+			v1 46 
+			v2 31 
+		} 
+		triangle 
+		{ 
+			v0 31 
+			v1 47 
+			v2 46 
+		} 
+		triangle 
+		{ 
+			v0 32 
+			v1 48 
+			v2 33 
+		} 
+		triangle 
+		{ 
+			v0 33 
+			v1 49 
+			v2 48 
+		} 
+		triangle 
+		{ 
+			v0 33 
+			v1 49 
+			v2 34 
+		} 
+		triangle 
+		{ 
+			v0 34 
+			v1 50 
+			v2 49 
+		} 
+		triangle 
+		{ 
+			v0 34 
+			v1 50 
+			v2 35 
+		} 
+		triangle 
+		{ 
+			v0 35 
+			v1 51 
+			v2 50 
+		} 
+		triangle 
+		{ 
+			v0 35 
+			v1 51 
+			v2 36 
+		} 
+		triangle 
+		{ 
+			v0 36 
+			v1 52 
+			v2 51 
+		} 
+		triangle 
+		{ 
+			v0 36 
+			v1 52 
+			v2 37 
+		} 
+		triangle 
+		{ 
+			v0 37 
+			v1 53 
+			v2 52 
+		} 
+		triangle 
+		{ 
+			v0 37 
+			v1 53 
+			v2 38 
+		} 
+		triangle 
+		{ 
+			v0 38 
+			v1 54 
+			v2 53 
+		} 
+		triangle 
+		{ 
+			v0 111 
+			v1 127 
+			v2 126 
+		} 
+		triangle 
+		{ 
+			v0 135 
+			v1 134 
+			v2 40 
+		} 
+		triangle 
+		{ 
+			v0 70 
+			v1 72 
+			v2 147 
+		} 
+		triangle 
+		{ 
+			v0 70 
+			v1 72 
+			v2 146 
+		} 
+		triangle 
+		{ 
+			v0 38 
+			v1 39 
+			v2 128 
+		} 
+		triangle 
+		{ 
+			v0 140 
+			v1 130 
+			v2 73 
+		} 
+		triangle 
+		{ 
+			v0 41 
+			v1 57 
+			v2 42 
+		} 
+		triangle 
+		{ 
+			v0 42 
+			v1 58 
+			v2 57 
+		} 
+		triangle 
+		{ 
+			v0 42 
+			v1 58 
+			v2 43 
+		} 
+		triangle 
+		{ 
+			v0 43 
+			v1 59 
+			v2 58 
+		} 
+		triangle 
+		{ 
+			v0 43 
+			v1 59 
+			v2 44 
+		} 
+		triangle 
+		{ 
+			v0 44 
+			v1 60 
+			v2 59 
+		} 
+		triangle 
+		{ 
+			v0 44 
+			v1 60 
+			v2 45 
+		} 
+		triangle 
+		{ 
+			v0 45 
+			v1 61 
+			v2 60 
+		} 
+		triangle 
+		{ 
+			v0 45 
+			v1 61 
+			v2 46 
+		} 
+		triangle 
+		{ 
+			v0 46 
+			v1 62 
+			v2 61 
+		} 
+		triangle 
+		{ 
+			v0 46 
+			v1 62 
+			v2 47 
+		} 
+		triangle 
+		{ 
+			v0 47 
+			v1 63 
+			v2 62 
+		} 
+		triangle 
+		{ 
+			v0 48 
+			v1 64 
+			v2 49 
+		} 
+		triangle 
+		{ 
+			v0 49 
+			v1 65 
+			v2 64 
+		} 
+		triangle 
+		{ 
+			v0 49 
+			v1 65 
+			v2 50 
+		} 
+		triangle 
+		{ 
+			v0 50 
+			v1 66 
+			v2 65 
+		} 
+		triangle 
+		{ 
+			v0 50 
+			v1 66 
+			v2 51 
+		} 
+		triangle 
+		{ 
+			v0 51 
+			v1 67 
+			v2 66 
+		} 
+		triangle 
+		{ 
+			v0 51 
+			v1 67 
+			v2 52 
+		} 
+		triangle 
+		{ 
+			v0 52 
+			v1 68 
+			v2 67 
+		} 
+		triangle 
+		{ 
+			v0 52 
+			v1 68 
+			v2 53 
+		} 
+		triangle 
+		{ 
+			v0 53 
+			v1 69 
+			v2 68 
+		} 
+		triangle 
+		{ 
+			v0 53 
+			v1 69 
+			v2 54 
+		} 
+		triangle 
+		{ 
+			v0 54 
+			v1 70 
+			v2 69 
+		} 
+		triangle 
+		{ 
+			v0 54 
+			v1 55 
+			v2 71 
+		} 
+		triangle 
+		{ 
+			v0 86 
+			v1 56 
+			v2 147 
+		} 
+		triangle 
+		{ 
+			v0 70 
+			v1 147 
+			v2 86 
+		} 
+		triangle 
+		{ 
+			v0 71 
+			v1 146 
+			v2 54 
+		} 
+		triangle 
+		{ 
+			v0 54 
+			v1 146 
+			v2 70 
+		} 
+		triangle 
+		{ 
+			v0 139 
+			v1 138 
+			v2 57 
+		} 
+		triangle 
+		{ 
+			v0 57 
+			v1 73 
+			v2 58 
+		} 
+		triangle 
+		{ 
+			v0 58 
+			v1 74 
+			v2 73 
+		} 
+		triangle 
+		{ 
+			v0 58 
+			v1 74 
+			v2 59 
+		} 
+		triangle 
+		{ 
+			v0 59 
+			v1 75 
+			v2 74 
+		} 
+		triangle 
+		{ 
+			v0 59 
+			v1 75 
+			v2 60 
+		} 
+		triangle 
+		{ 
+			v0 60 
+			v1 76 
+			v2 75 
+		} 
+		triangle 
+		{ 
+			v0 60 
+			v1 76 
+			v2 61 
+		} 
+		triangle 
+		{ 
+			v0 61 
+			v1 77 
+			v2 76 
+		} 
+		triangle 
+		{ 
+			v0 61 
+			v1 77 
+			v2 62 
+		} 
+		triangle 
+		{ 
+			v0 62 
+			v1 78 
+			v2 77 
+		} 
+		triangle 
+		{ 
+			v0 62 
+			v1 78 
+			v2 63 
+		} 
+		triangle 
+		{ 
+			v0 63 
+			v1 79 
+			v2 78 
+		} 
+		triangle 
+		{ 
+			v0 64 
+			v1 80 
+			v2 65 
+		} 
+		triangle 
+		{ 
+			v0 65 
+			v1 81 
+			v2 80 
+		} 
+		triangle 
+		{ 
+			v0 65 
+			v1 81 
+			v2 66 
+		} 
+		triangle 
+		{ 
+			v0 66 
+			v1 82 
+			v2 81 
+		} 
+		triangle 
+		{ 
+			v0 66 
+			v1 82 
+			v2 67 
+		} 
+		triangle 
+		{ 
+			v0 67 
+			v1 83 
+			v2 82 
+		} 
+		triangle 
+		{ 
+			v0 67 
+			v1 83 
+			v2 68 
+		} 
+		triangle 
+		{ 
+			v0 68 
+			v1 84 
+			v2 83 
+		} 
+		triangle 
+		{ 
+			v0 68 
+			v1 84 
+			v2 69 
+		} 
+		triangle 
+		{ 
+			v0 69 
+			v1 85 
+			v2 84 
+		} 
+		triangle 
+		{ 
+			v0 69 
+			v1 85 
+			v2 70 
+		} 
+		triangle 
+		{ 
+			v0 70 
+			v1 86 
+			v2 85 
+		} 
+		triangle 
+		{ 
+			v0 54 
+			v1 55 
+			v2 128 
+		} 
+		triangle 
+		{ 
+			v0 87 
+			v1 144 
+			v2 143 
+		} 
+		triangle 
+		{ 
+			v0 86 
+			v1 56 
+			v2 131 
+		} 
+		triangle 
+		{ 
+			v0 143 
+			v1 87 
+			v2 88 
+		} 
+		triangle 
+		{ 
+			v0 87 
+			v1 144 
+			v2 142 
+		} 
+		triangle 
+		{ 
+			v0 40 
+			v1 41 
+			v2 129 
+		} 
+		triangle 
+		{ 
+			v0 73 
+			v1 89 
+			v2 74 
+		} 
+		triangle 
+		{ 
+			v0 74 
+			v1 90 
+			v2 89 
+		} 
+		triangle 
+		{ 
+			v0 74 
+			v1 90 
+			v2 75 
+		} 
+		triangle 
+		{ 
+			v0 75 
+			v1 91 
+			v2 90 
+		} 
+		triangle 
+		{ 
+			v0 75 
+			v1 91 
+			v2 76 
+		} 
+		triangle 
+		{ 
+			v0 76 
+			v1 92 
+			v2 91 
+		} 
+		triangle 
+		{ 
+			v0 76 
+			v1 92 
+			v2 77 
+		} 
+		triangle 
+		{ 
+			v0 77 
+			v1 93 
+			v2 92 
+		} 
+		triangle 
+		{ 
+			v0 77 
+			v1 93 
+			v2 78 
+		} 
+		triangle 
+		{ 
+			v0 78 
+			v1 94 
+			v2 93 
+		} 
+		triangle 
+		{ 
+			v0 78 
+			v1 94 
+			v2 79 
+		} 
+		triangle 
+		{ 
+			v0 79 
+			v1 95 
+			v2 94 
+		} 
+		triangle 
+		{ 
+			v0 80 
+			v1 96 
+			v2 81 
+		} 
+		triangle 
+		{ 
+			v0 81 
+			v1 97 
+			v2 96 
+		} 
+		triangle 
+		{ 
+			v0 81 
+			v1 97 
+			v2 82 
+		} 
+		triangle 
+		{ 
+			v0 82 
+			v1 98 
+			v2 97 
+		} 
+		triangle 
+		{ 
+			v0 82 
+			v1 98 
+			v2 83 
+		} 
+		triangle 
+		{ 
+			v0 83 
+			v1 99 
+			v2 98 
+		} 
+		triangle 
+		{ 
+			v0 83 
+			v1 99 
+			v2 84 
+		} 
+		triangle 
+		{ 
+			v0 84 
+			v1 100 
+			v2 99 
+		} 
+		triangle 
+		{ 
+			v0 84 
+			v1 100 
+			v2 85 
+		} 
+		triangle 
+		{ 
+			v0 85 
+			v1 101 
+			v2 100 
+		} 
+		triangle 
+		{ 
+			v0 85 
+			v1 101 
+			v2 86 
+		} 
+		triangle 
+		{ 
+			v0 86 
+			v1 102 
+			v2 101 
+		} 
+		triangle 
+		{ 
+			v0 86 
+			v1 102 
+			v2 87 
+		} 
+		triangle 
+		{ 
+			v0 87 
+			v1 103 
+			v2 102 
+		} 
+		triangle 
+		{ 
+			v0 87 
+			v1 103 
+			v2 88 
+		} 
+		triangle 
+		{ 
+			v0 88 
+			v1 104 
+			v2 103 
+		} 
+		triangle 
+		{ 
+			v0 88 
+			v1 104 
+			v2 89 
+		} 
+		triangle 
+		{ 
+			v0 89 
+			v1 105 
+			v2 104 
+		} 
+		triangle 
+		{ 
+			v0 89 
+			v1 105 
+			v2 90 
+		} 
+		triangle 
+		{ 
+			v0 90 
+			v1 106 
+			v2 105 
+		} 
+		triangle 
+		{ 
+			v0 90 
+			v1 106 
+			v2 91 
+		} 
+		triangle 
+		{ 
+			v0 91 
+			v1 107 
+			v2 106 
+		} 
+		triangle 
+		{ 
+			v0 91 
+			v1 107 
+			v2 92 
+		} 
+		triangle 
+		{ 
+			v0 92 
+			v1 108 
+			v2 107 
+		} 
+		triangle 
+		{ 
+			v0 92 
+			v1 108 
+			v2 93 
+		} 
+		triangle 
+		{ 
+			v0 93 
+			v1 109 
+			v2 108 
+		} 
+		triangle 
+		{ 
+			v0 93 
+			v1 109 
+			v2 94 
+		} 
+		triangle 
+		{ 
+			v0 94 
+			v1 110 
+			v2 109 
+		} 
+		triangle 
+		{ 
+			v0 94 
+			v1 110 
+			v2 95 
+		} 
+		triangle 
+		{ 
+			v0 95 
+			v1 111 
+			v2 110 
+		} 
+		triangle 
+		{ 
+			v0 96 
+			v1 112 
+			v2 97 
+		} 
+		triangle 
+		{ 
+			v0 97 
+			v1 113 
+			v2 112 
+		} 
+		triangle 
+		{ 
+			v0 97 
+			v1 113 
+			v2 98 
+		} 
+		triangle 
+		{ 
+			v0 98 
+			v1 114 
+			v2 113 
+		} 
+		triangle 
+		{ 
+			v0 98 
+			v1 114 
+			v2 99 
+		} 
+		triangle 
+		{ 
+			v0 99 
+			v1 115 
+			v2 114 
+		} 
+		triangle 
+		{ 
+			v0 99 
+			v1 115 
+			v2 100 
+		} 
+		triangle 
+		{ 
+			v0 100 
+			v1 116 
+			v2 115 
+		} 
+		triangle 
+		{ 
+			v0 100 
+			v1 116 
+			v2 101 
+		} 
+		triangle 
+		{ 
+			v0 101 
+			v1 117 
+			v2 116 
+		} 
+		triangle 
+		{ 
+			v0 101 
+			v1 117 
+			v2 102 
+		} 
+		triangle 
+		{ 
+			v0 102 
+			v1 118 
+			v2 117 
+		} 
+		triangle 
+		{ 
+			v0 102 
+			v1 118 
+			v2 103 
+		} 
+		triangle 
+		{ 
+			v0 103 
+			v1 119 
+			v2 118 
+		} 
+		triangle 
+		{ 
+			v0 103 
+			v1 119 
+			v2 104 
+		} 
+		triangle 
+		{ 
+			v0 104 
+			v1 120 
+			v2 119 
+		} 
+		triangle 
+		{ 
+			v0 104 
+			v1 120 
+			v2 105 
+		} 
+		triangle 
+		{ 
+			v0 105 
+			v1 121 
+			v2 120 
+		} 
+		triangle 
+		{ 
+			v0 105 
+			v1 121 
+			v2 106 
+		} 
+		triangle 
+		{ 
+			v0 106 
+			v1 122 
+			v2 121 
+		} 
+		triangle 
+		{ 
+			v0 106 
+			v1 122 
+			v2 107 
+		} 
+		triangle 
+		{ 
+			v0 107 
+			v1 123 
+			v2 122 
+		} 
+		triangle 
+		{ 
+			v0 107 
+			v1 123 
+			v2 108 
+		} 
+		triangle 
+		{ 
+			v0 108 
+			v1 124 
+			v2 123 
+		} 
+		triangle 
+		{ 
+			v0 108 
+			v1 124 
+			v2 109 
+		} 
+		triangle 
+		{ 
+			v0 109 
+			v1 125 
+			v2 124 
+		} 
+		triangle 
+		{ 
+			v0 109 
+			v1 125 
+			v2 110 
+		} 
+		triangle 
+		{ 
+			v0 110 
+			v1 126 
+			v2 125 
+		} 
+		triangle 
+		{ 
+			v0 110 
+			v1 126 
+			v2 111 
+		} 
+		triangle 
+		{ 
+			v0 38 
+			v1 54 
+			v2 128 
+		} 
+		triangle 
+		{ 
+			v0 135 
+			v1 132 
+			v2 40 
+		} 
+		triangle 
+		{ 
+			v0 40 
+			v1 134 
+			v2 129 
+		} 
+		triangle 
+		{ 
+			v0 140 
+			v1 138 
+			v2 73 
+		} 
+		triangle 
+		{ 
+			v0 73 
+			v1 89 
+			v2 130 
+		} 
+		triangle 
+		{ 
+			v0 88 
+			v1 89 
+			v2 130 
+		} 
+		triangle 
+		{ 
+			v0 145 
+			v1 143 
+			v2 88 
+		} 
+		triangle 
+		{ 
+			v0 86 
+			v1 87 
+			v2 131 
+		} 
+		triangle 
+		{ 
+			v0 142 
+			v1 131 
+			v2 87 
+		} 
+		triangle 
+		{ 
+			v0 88 
+			v1 141 
+			v2 130 
+		} 
+		triangle 
+		{ 
+			v0 138 
+			v1 57 
+			v2 73 
+		} 
+		triangle 
+		{ 
+			v0 39 
+			v1 132 
+			v2 40 
+		} 
+		triangle 
+		{ 
+			v0 137 
+			v1 136 
+			v2 41 
+		} 
+		triangle 
+		{ 
+			v0 137 
+			v1 129 
+			v2 41 
+		} 
+		triangle 
+		{ 
+			v0 133 
+			v1 128 
+			v2 39 
+		} 
+		triangle 
+		{ 
+			v0 139 
+			v1 136 
+			v2 57 
+		} 
+		triangle 
+		{ 
+			v0 133 
+			v1 132 
+			v2 39 
+		} 
+		triangle 
+		{ 
+			v0 145 
+			v1 141 
+			v2 88 
+		} 
+		triangle 
+		{ 
+			v0 136 
+			v1 41 
+			v2 57 
+		} 
+	} 
+} 

--- a/Workbed/TopDownGame/temp/navmesh_roundtrip_test.navmesh
+++ b/Workbed/TopDownGame/temp/navmesh_roundtrip_test.navmesh
@@ -1,0 +1,2577 @@
+NavmeshData 
+{ 
+	vertices 
+	{ 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 100.000 
+				y 196.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 20.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 276.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 404.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 532.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 660.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 788.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 20.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 276.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 404.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 532.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 660.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 788.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1044.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1172.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1300.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1428.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1556.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1684.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1812.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1940.000 
+				y 916.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 100.000 
+				y 100.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 200.000 
+				y 100.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 200.000 
+				y 200.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 100.000 
+				y 200.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 100.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 196.000 
+				y 100.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 200.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 148.000 
+				y 200.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 100.000 
+				y 148.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 900.000 
+				y 300.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1000.000 
+				y 300.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1000.000 
+				y 400.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 900.000 
+				y 400.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 300.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 1000.000 
+				y 320.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 915.385 
+				y 400.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 919.231 
+				y 400.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 916.000 
+				y 400.000 
+			} 
+		} 
+		vertex 
+		{ 
+			pos 
+			{ 
+				x 920.000 
+				y 400.000 
+			} 
+		} 
+	} 
+	triangles 
+	{ 
+		triangle 
+		{ 
+			v0 0 
+			v1 1 
+			v2 2 
+		} 
+		triangle 
+		{ 
+			v0 111 
+			v1 127 
+			v2 126 
+		} 
+		triangle 
+		{ 
+			v0 1 
+			v1 136 
+			v2 32 
+		} 
+		triangle 
+		{ 
+			v0 1 
+			v1 2 
+			v2 128 
+		} 
+		triangle 
+		{ 
+			v0 4 
+			v1 5 
+			v2 6 
+		} 
+		triangle 
+		{ 
+			v0 6 
+			v1 7 
+			v2 5 
+		} 
+		triangle 
+		{ 
+			v0 6 
+			v1 7 
+			v2 8 
+		} 
+		triangle 
+		{ 
+			v0 8 
+			v1 9 
+			v2 7 
+		} 
+		triangle 
+		{ 
+			v0 8 
+			v1 9 
+			v2 10 
+		} 
+		triangle 
+		{ 
+			v0 10 
+			v1 11 
+			v2 9 
+		} 
+		triangle 
+		{ 
+			v0 10 
+			v1 11 
+			v2 12 
+		} 
+		triangle 
+		{ 
+			v0 12 
+			v1 13 
+			v2 11 
+		} 
+		triangle 
+		{ 
+			v0 12 
+			v1 13 
+			v2 14 
+		} 
+		triangle 
+		{ 
+			v0 14 
+			v1 15 
+			v2 13 
+		} 
+		triangle 
+		{ 
+			v0 14 
+			v1 15 
+			v2 16 
+		} 
+		triangle 
+		{ 
+			v0 16 
+			v1 17 
+			v2 15 
+		} 
+		triangle 
+		{ 
+			v0 16 
+			v1 17 
+			v2 18 
+		} 
+		triangle 
+		{ 
+			v0 18 
+			v1 19 
+			v2 17 
+		} 
+		triangle 
+		{ 
+			v0 18 
+			v1 19 
+			v2 20 
+		} 
+		triangle 
+		{ 
+			v0 20 
+			v1 21 
+			v2 19 
+		} 
+		triangle 
+		{ 
+			v0 20 
+			v1 21 
+			v2 22 
+		} 
+		triangle 
+		{ 
+			v0 22 
+			v1 23 
+			v2 21 
+		} 
+		triangle 
+		{ 
+			v0 22 
+			v1 23 
+			v2 24 
+		} 
+		triangle 
+		{ 
+			v0 24 
+			v1 25 
+			v2 23 
+		} 
+		triangle 
+		{ 
+			v0 24 
+			v1 25 
+			v2 26 
+		} 
+		triangle 
+		{ 
+			v0 26 
+			v1 27 
+			v2 25 
+		} 
+		triangle 
+		{ 
+			v0 26 
+			v1 27 
+			v2 28 
+		} 
+		triangle 
+		{ 
+			v0 28 
+			v1 29 
+			v2 27 
+		} 
+		triangle 
+		{ 
+			v0 28 
+			v1 29 
+			v2 30 
+		} 
+		triangle 
+		{ 
+			v0 30 
+			v1 31 
+			v2 29 
+		} 
+		triangle 
+		{ 
+			v0 32 
+			v1 3 
+			v2 131 
+		} 
+		triangle 
+		{ 
+			v0 1 
+			v1 136 
+			v2 128 
+		} 
+		triangle 
+		{ 
+			v0 135 
+			v1 131 
+			v2 33 
+		} 
+		triangle 
+		{ 
+			v0 5 
+			v1 34 
+			v2 33 
+		} 
+		triangle 
+		{ 
+			v0 5 
+			v1 34 
+			v2 7 
+		} 
+		triangle 
+		{ 
+			v0 7 
+			v1 35 
+			v2 34 
+		} 
+		triangle 
+		{ 
+			v0 7 
+			v1 35 
+			v2 9 
+		} 
+		triangle 
+		{ 
+			v0 9 
+			v1 36 
+			v2 35 
+		} 
+		triangle 
+		{ 
+			v0 9 
+			v1 36 
+			v2 11 
+		} 
+		triangle 
+		{ 
+			v0 11 
+			v1 37 
+			v2 36 
+		} 
+		triangle 
+		{ 
+			v0 11 
+			v1 37 
+			v2 13 
+		} 
+		triangle 
+		{ 
+			v0 13 
+			v1 38 
+			v2 37 
+		} 
+		triangle 
+		{ 
+			v0 13 
+			v1 38 
+			v2 15 
+		} 
+		triangle 
+		{ 
+			v0 15 
+			v1 39 
+			v2 38 
+		} 
+		triangle 
+		{ 
+			v0 15 
+			v1 39 
+			v2 17 
+		} 
+		triangle 
+		{ 
+			v0 17 
+			v1 40 
+			v2 39 
+		} 
+		triangle 
+		{ 
+			v0 17 
+			v1 40 
+			v2 19 
+		} 
+		triangle 
+		{ 
+			v0 19 
+			v1 41 
+			v2 40 
+		} 
+		triangle 
+		{ 
+			v0 19 
+			v1 41 
+			v2 21 
+		} 
+		triangle 
+		{ 
+			v0 21 
+			v1 42 
+			v2 41 
+		} 
+		triangle 
+		{ 
+			v0 21 
+			v1 42 
+			v2 23 
+		} 
+		triangle 
+		{ 
+			v0 23 
+			v1 43 
+			v2 42 
+		} 
+		triangle 
+		{ 
+			v0 23 
+			v1 43 
+			v2 25 
+		} 
+		triangle 
+		{ 
+			v0 25 
+			v1 44 
+			v2 43 
+		} 
+		triangle 
+		{ 
+			v0 25 
+			v1 44 
+			v2 27 
+		} 
+		triangle 
+		{ 
+			v0 27 
+			v1 45 
+			v2 44 
+		} 
+		triangle 
+		{ 
+			v0 27 
+			v1 45 
+			v2 29 
+		} 
+		triangle 
+		{ 
+			v0 29 
+			v1 46 
+			v2 45 
+		} 
+		triangle 
+		{ 
+			v0 29 
+			v1 46 
+			v2 31 
+		} 
+		triangle 
+		{ 
+			v0 31 
+			v1 47 
+			v2 46 
+		} 
+		triangle 
+		{ 
+			v0 32 
+			v1 48 
+			v2 33 
+		} 
+		triangle 
+		{ 
+			v0 33 
+			v1 49 
+			v2 48 
+		} 
+		triangle 
+		{ 
+			v0 33 
+			v1 49 
+			v2 34 
+		} 
+		triangle 
+		{ 
+			v0 34 
+			v1 50 
+			v2 49 
+		} 
+		triangle 
+		{ 
+			v0 34 
+			v1 50 
+			v2 35 
+		} 
+		triangle 
+		{ 
+			v0 35 
+			v1 51 
+			v2 50 
+		} 
+		triangle 
+		{ 
+			v0 35 
+			v1 51 
+			v2 36 
+		} 
+		triangle 
+		{ 
+			v0 36 
+			v1 52 
+			v2 51 
+		} 
+		triangle 
+		{ 
+			v0 36 
+			v1 52 
+			v2 37 
+		} 
+		triangle 
+		{ 
+			v0 37 
+			v1 53 
+			v2 52 
+		} 
+		triangle 
+		{ 
+			v0 37 
+			v1 53 
+			v2 38 
+		} 
+		triangle 
+		{ 
+			v0 38 
+			v1 54 
+			v2 53 
+		} 
+		triangle 
+		{ 
+			v0 38 
+			v1 54 
+			v2 39 
+		} 
+		triangle 
+		{ 
+			v0 2 
+			v1 132 
+			v2 4 
+		} 
+		triangle 
+		{ 
+			v0 54 
+			v1 39 
+			v2 137 
+		} 
+		triangle 
+		{ 
+			v0 39 
+			v1 40 
+			v2 138 
+		} 
+		triangle 
+		{ 
+			v0 40 
+			v1 56 
+			v2 41 
+		} 
+		triangle 
+		{ 
+			v0 41 
+			v1 57 
+			v2 56 
+		} 
+		triangle 
+		{ 
+			v0 41 
+			v1 57 
+			v2 42 
+		} 
+		triangle 
+		{ 
+			v0 42 
+			v1 58 
+			v2 57 
+		} 
+		triangle 
+		{ 
+			v0 42 
+			v1 58 
+			v2 43 
+		} 
+		triangle 
+		{ 
+			v0 43 
+			v1 59 
+			v2 58 
+		} 
+		triangle 
+		{ 
+			v0 43 
+			v1 59 
+			v2 44 
+		} 
+		triangle 
+		{ 
+			v0 44 
+			v1 60 
+			v2 59 
+		} 
+		triangle 
+		{ 
+			v0 44 
+			v1 60 
+			v2 45 
+		} 
+		triangle 
+		{ 
+			v0 45 
+			v1 61 
+			v2 60 
+		} 
+		triangle 
+		{ 
+			v0 45 
+			v1 61 
+			v2 46 
+		} 
+		triangle 
+		{ 
+			v0 46 
+			v1 62 
+			v2 61 
+		} 
+		triangle 
+		{ 
+			v0 46 
+			v1 62 
+			v2 47 
+		} 
+		triangle 
+		{ 
+			v0 47 
+			v1 63 
+			v2 62 
+		} 
+		triangle 
+		{ 
+			v0 48 
+			v1 64 
+			v2 49 
+		} 
+		triangle 
+		{ 
+			v0 49 
+			v1 65 
+			v2 64 
+		} 
+		triangle 
+		{ 
+			v0 49 
+			v1 65 
+			v2 50 
+		} 
+		triangle 
+		{ 
+			v0 50 
+			v1 66 
+			v2 65 
+		} 
+		triangle 
+		{ 
+			v0 50 
+			v1 66 
+			v2 51 
+		} 
+		triangle 
+		{ 
+			v0 51 
+			v1 67 
+			v2 66 
+		} 
+		triangle 
+		{ 
+			v0 51 
+			v1 67 
+			v2 52 
+		} 
+		triangle 
+		{ 
+			v0 52 
+			v1 68 
+			v2 67 
+		} 
+		triangle 
+		{ 
+			v0 52 
+			v1 68 
+			v2 53 
+		} 
+		triangle 
+		{ 
+			v0 53 
+			v1 69 
+			v2 68 
+		} 
+		triangle 
+		{ 
+			v0 53 
+			v1 69 
+			v2 54 
+		} 
+		triangle 
+		{ 
+			v0 54 
+			v1 70 
+			v2 69 
+		} 
+		triangle 
+		{ 
+			v0 54 
+			v1 70 
+			v2 55 
+		} 
+		triangle 
+		{ 
+			v0 55 
+			v1 71 
+			v2 70 
+		} 
+		triangle 
+		{ 
+			v0 55 
+			v1 71 
+			v2 56 
+		} 
+		triangle 
+		{ 
+			v0 56 
+			v1 72 
+			v2 71 
+		} 
+		triangle 
+		{ 
+			v0 56 
+			v1 72 
+			v2 57 
+		} 
+		triangle 
+		{ 
+			v0 57 
+			v1 73 
+			v2 72 
+		} 
+		triangle 
+		{ 
+			v0 57 
+			v1 73 
+			v2 58 
+		} 
+		triangle 
+		{ 
+			v0 58 
+			v1 74 
+			v2 73 
+		} 
+		triangle 
+		{ 
+			v0 58 
+			v1 74 
+			v2 59 
+		} 
+		triangle 
+		{ 
+			v0 59 
+			v1 75 
+			v2 74 
+		} 
+		triangle 
+		{ 
+			v0 59 
+			v1 75 
+			v2 60 
+		} 
+		triangle 
+		{ 
+			v0 60 
+			v1 76 
+			v2 75 
+		} 
+		triangle 
+		{ 
+			v0 60 
+			v1 76 
+			v2 61 
+		} 
+		triangle 
+		{ 
+			v0 61 
+			v1 77 
+			v2 76 
+		} 
+		triangle 
+		{ 
+			v0 61 
+			v1 77 
+			v2 62 
+		} 
+		triangle 
+		{ 
+			v0 62 
+			v1 78 
+			v2 77 
+		} 
+		triangle 
+		{ 
+			v0 62 
+			v1 78 
+			v2 63 
+		} 
+		triangle 
+		{ 
+			v0 63 
+			v1 79 
+			v2 78 
+		} 
+		triangle 
+		{ 
+			v0 64 
+			v1 80 
+			v2 65 
+		} 
+		triangle 
+		{ 
+			v0 65 
+			v1 81 
+			v2 80 
+		} 
+		triangle 
+		{ 
+			v0 65 
+			v1 81 
+			v2 66 
+		} 
+		triangle 
+		{ 
+			v0 66 
+			v1 82 
+			v2 81 
+		} 
+		triangle 
+		{ 
+			v0 66 
+			v1 82 
+			v2 67 
+		} 
+		triangle 
+		{ 
+			v0 67 
+			v1 83 
+			v2 82 
+		} 
+		triangle 
+		{ 
+			v0 67 
+			v1 83 
+			v2 68 
+		} 
+		triangle 
+		{ 
+			v0 68 
+			v1 84 
+			v2 83 
+		} 
+		triangle 
+		{ 
+			v0 68 
+			v1 84 
+			v2 69 
+		} 
+		triangle 
+		{ 
+			v0 69 
+			v1 85 
+			v2 84 
+		} 
+		triangle 
+		{ 
+			v0 69 
+			v1 85 
+			v2 70 
+		} 
+		triangle 
+		{ 
+			v0 70 
+			v1 86 
+			v2 85 
+		} 
+		triangle 
+		{ 
+			v0 70 
+			v1 86 
+			v2 71 
+		} 
+		triangle 
+		{ 
+			v0 71 
+			v1 87 
+			v2 86 
+		} 
+		triangle 
+		{ 
+			v0 71 
+			v1 87 
+			v2 72 
+		} 
+		triangle 
+		{ 
+			v0 72 
+			v1 88 
+			v2 87 
+		} 
+		triangle 
+		{ 
+			v0 72 
+			v1 88 
+			v2 73 
+		} 
+		triangle 
+		{ 
+			v0 73 
+			v1 89 
+			v2 88 
+		} 
+		triangle 
+		{ 
+			v0 73 
+			v1 89 
+			v2 74 
+		} 
+		triangle 
+		{ 
+			v0 74 
+			v1 90 
+			v2 89 
+		} 
+		triangle 
+		{ 
+			v0 74 
+			v1 90 
+			v2 75 
+		} 
+		triangle 
+		{ 
+			v0 75 
+			v1 91 
+			v2 90 
+		} 
+		triangle 
+		{ 
+			v0 75 
+			v1 91 
+			v2 76 
+		} 
+		triangle 
+		{ 
+			v0 76 
+			v1 92 
+			v2 91 
+		} 
+		triangle 
+		{ 
+			v0 76 
+			v1 92 
+			v2 77 
+		} 
+		triangle 
+		{ 
+			v0 77 
+			v1 93 
+			v2 92 
+		} 
+		triangle 
+		{ 
+			v0 77 
+			v1 93 
+			v2 78 
+		} 
+		triangle 
+		{ 
+			v0 78 
+			v1 94 
+			v2 93 
+		} 
+		triangle 
+		{ 
+			v0 78 
+			v1 94 
+			v2 79 
+		} 
+		triangle 
+		{ 
+			v0 79 
+			v1 95 
+			v2 94 
+		} 
+		triangle 
+		{ 
+			v0 80 
+			v1 96 
+			v2 81 
+		} 
+		triangle 
+		{ 
+			v0 81 
+			v1 97 
+			v2 96 
+		} 
+		triangle 
+		{ 
+			v0 81 
+			v1 97 
+			v2 82 
+		} 
+		triangle 
+		{ 
+			v0 82 
+			v1 98 
+			v2 97 
+		} 
+		triangle 
+		{ 
+			v0 82 
+			v1 98 
+			v2 83 
+		} 
+		triangle 
+		{ 
+			v0 83 
+			v1 99 
+			v2 98 
+		} 
+		triangle 
+		{ 
+			v0 83 
+			v1 99 
+			v2 84 
+		} 
+		triangle 
+		{ 
+			v0 84 
+			v1 100 
+			v2 99 
+		} 
+		triangle 
+		{ 
+			v0 84 
+			v1 100 
+			v2 85 
+		} 
+		triangle 
+		{ 
+			v0 85 
+			v1 101 
+			v2 100 
+		} 
+		triangle 
+		{ 
+			v0 85 
+			v1 101 
+			v2 86 
+		} 
+		triangle 
+		{ 
+			v0 86 
+			v1 102 
+			v2 101 
+		} 
+		triangle 
+		{ 
+			v0 86 
+			v1 102 
+			v2 87 
+		} 
+		triangle 
+		{ 
+			v0 87 
+			v1 103 
+			v2 102 
+		} 
+		triangle 
+		{ 
+			v0 87 
+			v1 103 
+			v2 88 
+		} 
+		triangle 
+		{ 
+			v0 88 
+			v1 104 
+			v2 103 
+		} 
+		triangle 
+		{ 
+			v0 88 
+			v1 104 
+			v2 89 
+		} 
+		triangle 
+		{ 
+			v0 89 
+			v1 105 
+			v2 104 
+		} 
+		triangle 
+		{ 
+			v0 89 
+			v1 105 
+			v2 90 
+		} 
+		triangle 
+		{ 
+			v0 90 
+			v1 106 
+			v2 105 
+		} 
+		triangle 
+		{ 
+			v0 90 
+			v1 106 
+			v2 91 
+		} 
+		triangle 
+		{ 
+			v0 91 
+			v1 107 
+			v2 106 
+		} 
+		triangle 
+		{ 
+			v0 91 
+			v1 107 
+			v2 92 
+		} 
+		triangle 
+		{ 
+			v0 92 
+			v1 108 
+			v2 107 
+		} 
+		triangle 
+		{ 
+			v0 92 
+			v1 108 
+			v2 93 
+		} 
+		triangle 
+		{ 
+			v0 93 
+			v1 109 
+			v2 108 
+		} 
+		triangle 
+		{ 
+			v0 93 
+			v1 109 
+			v2 94 
+		} 
+		triangle 
+		{ 
+			v0 94 
+			v1 110 
+			v2 109 
+		} 
+		triangle 
+		{ 
+			v0 94 
+			v1 110 
+			v2 95 
+		} 
+		triangle 
+		{ 
+			v0 95 
+			v1 111 
+			v2 110 
+		} 
+		triangle 
+		{ 
+			v0 96 
+			v1 112 
+			v2 97 
+		} 
+		triangle 
+		{ 
+			v0 97 
+			v1 113 
+			v2 112 
+		} 
+		triangle 
+		{ 
+			v0 97 
+			v1 113 
+			v2 98 
+		} 
+		triangle 
+		{ 
+			v0 98 
+			v1 114 
+			v2 113 
+		} 
+		triangle 
+		{ 
+			v0 98 
+			v1 114 
+			v2 99 
+		} 
+		triangle 
+		{ 
+			v0 99 
+			v1 115 
+			v2 114 
+		} 
+		triangle 
+		{ 
+			v0 99 
+			v1 115 
+			v2 100 
+		} 
+		triangle 
+		{ 
+			v0 100 
+			v1 116 
+			v2 115 
+		} 
+		triangle 
+		{ 
+			v0 100 
+			v1 116 
+			v2 101 
+		} 
+		triangle 
+		{ 
+			v0 101 
+			v1 117 
+			v2 116 
+		} 
+		triangle 
+		{ 
+			v0 101 
+			v1 117 
+			v2 102 
+		} 
+		triangle 
+		{ 
+			v0 102 
+			v1 118 
+			v2 117 
+		} 
+		triangle 
+		{ 
+			v0 102 
+			v1 118 
+			v2 103 
+		} 
+		triangle 
+		{ 
+			v0 103 
+			v1 119 
+			v2 118 
+		} 
+		triangle 
+		{ 
+			v0 103 
+			v1 119 
+			v2 104 
+		} 
+		triangle 
+		{ 
+			v0 104 
+			v1 120 
+			v2 119 
+		} 
+		triangle 
+		{ 
+			v0 104 
+			v1 120 
+			v2 105 
+		} 
+		triangle 
+		{ 
+			v0 105 
+			v1 121 
+			v2 120 
+		} 
+		triangle 
+		{ 
+			v0 105 
+			v1 121 
+			v2 106 
+		} 
+		triangle 
+		{ 
+			v0 106 
+			v1 122 
+			v2 121 
+		} 
+		triangle 
+		{ 
+			v0 106 
+			v1 122 
+			v2 107 
+		} 
+		triangle 
+		{ 
+			v0 107 
+			v1 123 
+			v2 122 
+		} 
+		triangle 
+		{ 
+			v0 107 
+			v1 123 
+			v2 108 
+		} 
+		triangle 
+		{ 
+			v0 108 
+			v1 124 
+			v2 123 
+		} 
+		triangle 
+		{ 
+			v0 108 
+			v1 124 
+			v2 109 
+		} 
+		triangle 
+		{ 
+			v0 109 
+			v1 125 
+			v2 124 
+		} 
+		triangle 
+		{ 
+			v0 109 
+			v1 125 
+			v2 110 
+		} 
+		triangle 
+		{ 
+			v0 110 
+			v1 126 
+			v2 125 
+		} 
+		triangle 
+		{ 
+			v0 110 
+			v1 126 
+			v2 111 
+		} 
+		triangle 
+		{ 
+			v0 133 
+			v1 129 
+			v2 4 
+		} 
+		triangle 
+		{ 
+			v0 134 
+			v1 129 
+			v2 5 
+		} 
+		triangle 
+		{ 
+			v0 4 
+			v1 5 
+			v2 129 
+		} 
+		triangle 
+		{ 
+			v0 134 
+			v1 130 
+			v2 5 
+		} 
+		triangle 
+		{ 
+			v0 133 
+			v1 132 
+			v2 4 
+		} 
+		triangle 
+		{ 
+			v0 33 
+			v1 5 
+			v2 130 
+		} 
+		triangle 
+		{ 
+			v0 135 
+			v1 130 
+			v2 33 
+		} 
+		triangle 
+		{ 
+			v0 32 
+			v1 33 
+			v2 131 
+		} 
+		triangle 
+		{ 
+			v0 32 
+			v1 3 
+			v2 136 
+		} 
+		triangle 
+		{ 
+			v0 2 
+			v1 132 
+			v2 128 
+		} 
+		triangle 
+		{ 
+			v0 145 
+			v1 143 
+			v2 55 
+		} 
+		triangle 
+		{ 
+			v0 143 
+			v1 140 
+			v2 55 
+		} 
+		triangle 
+		{ 
+			v0 39 
+			v1 141 
+			v2 138 
+		} 
+		triangle 
+		{ 
+			v0 142 
+			v1 139 
+			v2 40 
+		} 
+		triangle 
+		{ 
+			v0 40 
+			v1 56 
+			v2 139 
+		} 
+		triangle 
+		{ 
+			v0 55 
+			v1 56 
+			v2 139 
+		} 
+		triangle 
+		{ 
+			v0 54 
+			v1 55 
+			v2 140 
+		} 
+		triangle 
+		{ 
+			v0 55 
+			v1 146 
+			v2 139 
+		} 
+		triangle 
+		{ 
+			v0 137 
+			v1 54 
+			v2 140 
+		} 
+		triangle 
+		{ 
+			v0 39 
+			v1 141 
+			v2 137 
+		} 
+		triangle 
+		{ 
+			v0 145 
+			v1 144 
+			v2 55 
+		} 
+		triangle 
+		{ 
+			v0 55 
+			v1 146 
+			v2 144 
+		} 
+		triangle 
+		{ 
+			v0 142 
+			v1 138 
+			v2 40 
+		} 
+	} 
+} 


### PR DESCRIPTION
## Description

TopDownGame gains a Level/LevelData asset-loading pipeline, following ActionGame's Level/LevelData pattern.

Closes #66

## Agent End-of-run Summary

All 4 phases of issue #66 are implemented, committed, and verified headlessly. Here's the end-of-run summary:

**Phases completed:**
- **Phase 1** (`d9304c1`) — Extracted `Navmesh`'s procedural grid-building into `GenerateDefaultGrid()`; verified via build + headless screenshot showing identical rendering to before.
- **Phase 2** (`b00d705`) — Added `Navmesh::Save()/Load()` + a `FindOrCreateEdge` helper, and the `NavmeshData` asset. Seeded `navmesh_main.navmesh` programmatically (via the same `DataAsset` codepath the editor UI would use, since mouse-driven UI authoring is out of scope for me per this repo's CLAUDE.md).
- **Phase 3** (`6d342a9`) — Added `LevelData` (start/goal positions + `AssetReference<NavmeshData>`), seeded `level_main.tdlevel` the same way.
- **Phase 4** (`730f3c6`) — Added the runtime `Level` class; `main.cpp` now runs entirely off loaded assets instead of the hardcoded grid. Headless screenshot confirmed the loaded level renders with the Phase 2 cut intact.

**Notable issue hit during the run:** a background code-review agent (Step 8) caught that my Phase 2 round-trip unit test was writing its fixture into `data/navmeshes/` — the same folder scanned by `AssetStorage<NavmeshData>` on every launch — so it was leaking in as a permanent, visible fake asset (`navmesh_roundtrip_test`) next to the real `navmesh_main` on every run, not just during tests. Fixed (`ee05bc4`) by driving `NavmeshData::OnParse()` directly into a `temp/` scratch file instead, mirroring the existing `fileProcessorTests.output` precedent. Also tightened a fragile exact-float-equality assertion to an epsilon compare, since `AssetParser`'s serialization is lossy (`%.3f`). One minor low-severity finding (an O(vertices×triangles) linear scan in `Save()`) was reported but not fixed — not a correctness issue, and negligible at current mesh sizes.

Since this repo declares a manual-test gate for TopDownGame, implementation stopped there rather than pushing/opening a PR immediately. The user then launched `Workbed\TopDownGame\TopDownGame.exe` directly (no flags) and confirmed the level loads/renders correctly, with no itemized checklist (the issue's phases had no formally-titled "Manual acceptance checklist" sections) — a general go/no-go, which passed.

## Agent Verifications

- **Phase 1**: Full solution build succeeded with 0 errors. Headless launch (`-hidewindow -usedebuginput`, `Input::KeyCode::_F10` screenshot capture) did not crash or assert during `FW_UnitTestSuite::RunTests()` / `NavmeshTestSuite::RunTests()` startup, and the captured screenshot showed the navmesh grid and mouse-hover/cut-line rendering identically to pre-refactor behavior.
- **Phase 2**: Build succeeded. Headless launch again completed unit tests without crashing, including the new `TestNavmeshSaveLoadRoundTrip` case (cuts two holes into a generated grid, saves through a `NavmeshData`, loads into a second instance, asserts matching vertex/triangle counts and matching `FindPath()` waypoints). The programmatically-seeded `Workbed/TopDownGame/Data/navmeshes/navmesh_main.navmesh` was confirmed present and loaded cleanly on a subsequent headless relaunch, with no `SLUSH_ERROR`/`SLUSH_WARNING` in the debug log.
- **Phase 3**: Build succeeded. The programmatically-seeded `Workbed/TopDownGame/Data/levels/level_main.tdlevel` was confirmed to contain `navmeshData navmesh_main`, and a headless relaunch loaded both assets cleanly with no missing-asset errors/warnings in the debug log.
- **Phase 4**: Build succeeded (both `/t:TopDownGame` and a full `Solution.sln` build, confirming ActionGame/BossMonster were unaffected by the `TopDownGame.vcxproj` `IncludePath` change). Headless launch confirmed `Level::Level()`'s `FW_ASSERT`s pass (no crash resolving `level_main`/its navmesh reference), and the captured screenshot showed the loaded level's navmesh rendering with the Phase 2 seed's cut intact — confirming the game runs entirely off `LevelData`/`NavmeshData` assets rather than the old hardcoded grid.
- **Review-driven fix**: After the round-trip-test-pollution bug was found and fixed, a fresh full solution build (0 errors) and headless relaunch confirmed no crash and that `data/navmeshes/` contains only the real `navmesh_main.navmesh`, with the test fixture correctly landing in `temp/navmesh_roundtrip_test.navmesh` instead.
