### PR TITLE
Terrain/spawn-goal editor tooling

### DIFF
--- a/Solution/Engine/Core/Dockables/IAppLayout.cpp
+++ b/Solution/Engine/Core/Dockables/IAppLayout.cpp
@@ -4,8 +4,9 @@
 
 namespace Slush
 {
-	IAppLayout::IAppLayout(const char* aLayoutName)
+	IAppLayout::IAppLayout(const char* aLayoutName, const char* aMenuLabel)
 		: myName(aLayoutName)
+		, myMenuLabel(aMenuLabel ? aMenuLabel : aLayoutName)
 	{
 	}
 

--- a/Solution/Engine/Core/Dockables/IAppLayout.h
+++ b/Solution/Engine/Core/Dockables/IAppLayout.h
@@ -74,4 +74,16 @@ namespace Slush
 		Dockable* myCloseRequestBlocker = nullptr;
 		bool myCloseWasCancelled = false;
 	};
+
+	// Creates a fresh IAppLayout instance on demand - used by Window's "Layouts" menu registry so a
+	// menu-driven switch can construct a brand new layout each time without Window needing to know each
+	// layout's own constructor arguments.
+	class IAppLayoutFactory
+	{
+	public:
+		virtual ~IAppLayoutFactory() {}
+
+		virtual const char* GetMenuLabel() const = 0;
+		virtual IAppLayout* CreateLayout() const = 0;
+	};
 }

--- a/Solution/Engine/Core/Dockables/IAppLayout.h
+++ b/Solution/Engine/Core/Dockables/IAppLayout.h
@@ -8,13 +8,16 @@ namespace Slush
 	class IAppLayout
 	{
 	public:
-		IAppLayout(const char* aLayoutName);
+		// aMenuLabel is what Window's "Layouts" menu displays for this layout; defaults to aLayoutName
+		// when a layout has no need for a separate human-readable label.
+		IAppLayout(const char* aLayoutName, const char* aMenuLabel = nullptr);
 		virtual ~IAppLayout();;
 		void Update();
 		void BuildUI();
 		void Render();
 
 		const FW_String& GetName() const { return myName; }
+		const FW_String& GetMenuLabel() const { return myMenuLabel; }
 
 		bool HasUnsavedChanges() const;
 
@@ -68,22 +71,11 @@ namespace Slush
 
 	private:
 		FW_String myName;
+		FW_String myMenuLabel;
 		FW_GrowingArray<Dockable*> myDockables;
 		int myNextDockableID = 0;
 
 		Dockable* myCloseRequestBlocker = nullptr;
 		bool myCloseWasCancelled = false;
-	};
-
-	// Creates a fresh IAppLayout instance on demand - used by Window's "Layouts" menu registry so a
-	// menu-driven switch can construct a brand new layout each time without Window needing to know each
-	// layout's own constructor arguments.
-	class IAppLayoutFactory
-	{
-	public:
-		virtual ~IAppLayoutFactory() {}
-
-		virtual const char* GetMenuLabel() const = 0;
-		virtual IAppLayout* CreateLayout() const = 0;
 	};
 }

--- a/Solution/Engine/Core/IApp.h
+++ b/Solution/Engine/Core/IApp.h
@@ -10,9 +10,9 @@ namespace Slush
 
 		virtual void Update() {};
 
-		// Not dead despite ActionGame's override being empty - BossMonster (main.cpp) and TopDownGame
-		// (main.cpp) have no game-rendering IAppLayout and use this as their only render entry point,
-		// wrapping StartOffscreenBuffer()/EndOffscreenBuffer() around their draws.
+		// Not dead despite ActionGame's override being empty - BossMonster (main.cpp) has no
+		// game-rendering IAppLayout and uses this as its only render entry point, wrapping
+		// StartOffscreenBuffer()/EndOffscreenBuffer() around its draws.
 		virtual void Render() {};
 	};
 }

--- a/Solution/Engine/Graphics/Window.cpp
+++ b/Solution/Engine/Graphics/Window.cpp
@@ -45,6 +45,8 @@ namespace Slush
 	{
 		SaveAppLayoutConfig();
 
+		myRegisteredLayouts.DeleteAll();
+
 		FW_SAFE_DELETE(myRenderer);
 		FW_SAFE_DELETE(myRenderWindow);
 	}
@@ -102,8 +104,11 @@ namespace Slush
 
 			if (ImGui::BeginMenu("Layouts"))
 			{
-				ImGui::Selectable("Game");
-				ImGui::Selectable("Entity");
+				for (IAppLayoutFactory* factory : myRegisteredLayouts)
+				{
+					if (ImGui::Selectable(factory->GetMenuLabel()))
+						RequestLayoutSwitch(*factory);
+				}
 				ImGui::EndMenu();
 			}
 
@@ -193,7 +198,7 @@ namespace Slush
 			return;
 		}
 
-		myCloseRequested = true;
+		myPendingTransition = PendingTransition::Close;
 	}
 
 	void Window::ConfirmClose(const char* aReason)
@@ -202,15 +207,32 @@ namespace Slush
 		myShouldBeOpen = false;
 	}
 
+	void Window::RegisterLayout(IAppLayoutFactory* aFactory)
+	{
+		FW_ASSERT(aFactory, "RegisterLayout: aFactory is null");
+		myRegisteredLayouts.Add(aFactory);
+	}
+
+	void Window::RequestLayoutSwitch(IAppLayoutFactory& aFactory)
+	{
+		if (!myAppLayout || !myAppLayout->HasUnsavedChanges())
+		{
+			SetAppLayout(aFactory.CreateLayout());
+			return;
+		}
+
+		myPendingTransition = PendingTransition::SwitchLayout;
+		myPendingLayoutFactory = &aFactory;
+	}
+
 	void Window::UpdatePendingClose()
 	{
-		if (!myCloseRequested)
+		if (myPendingTransition == PendingTransition::None)
 			return;
 
 		if (!myAppLayout)
 		{
-			ConfirmClose("no app layout");
-			myCloseRequested = false;
+			ResolvePendingTransition("no app layout");
 			return;
 		}
 
@@ -221,13 +243,35 @@ namespace Slush
 		switch (myAppLayout->RequestClose())
 		{
 		case IAppLayout::CloseRequestResult::Resolved:
-			ConfirmClose("unsaved changes resolved");
-			myCloseRequested = false;
+			ResolvePendingTransition("unsaved changes resolved");
 			break;
 		case IAppLayout::CloseRequestResult::Cancelled:
-			myCloseRequested = false;
+			myPendingTransition = PendingTransition::None;
+			myPendingLayoutFactory = nullptr;
 			break;
 		case IAppLayout::CloseRequestResult::StillPending:
+			break;
+		}
+	}
+
+	void Window::ResolvePendingTransition(const char* aCloseReason)
+	{
+		const PendingTransition transition = myPendingTransition;
+		IAppLayoutFactory* factory = myPendingLayoutFactory;
+
+		myPendingTransition = PendingTransition::None;
+		myPendingLayoutFactory = nullptr;
+
+		switch (transition)
+		{
+		case PendingTransition::Close:
+			ConfirmClose(aCloseReason);
+			break;
+		case PendingTransition::SwitchLayout:
+			FW_ASSERT(factory, "Pending layout switch resolved with no target factory");
+			SetAppLayout(factory->CreateLayout());
+			break;
+		case PendingTransition::None:
 			break;
 		}
 	}

--- a/Solution/Engine/Graphics/Window.cpp
+++ b/Solution/Engine/Graphics/Window.cpp
@@ -45,7 +45,7 @@ namespace Slush
 	{
 		SaveAppLayoutConfig();
 
-		myRegisteredLayouts.DeleteAll();
+		myLayouts.DeleteAll();
 
 		FW_SAFE_DELETE(myRenderer);
 		FW_SAFE_DELETE(myRenderWindow);
@@ -104,10 +104,10 @@ namespace Slush
 
 			if (ImGui::BeginMenu("Layouts"))
 			{
-				for (IAppLayoutFactory* factory : myRegisteredLayouts)
+				for (IAppLayout* layout : myLayouts)
 				{
-					if (ImGui::Selectable(factory->GetMenuLabel()))
-						RequestLayoutSwitch(*factory);
+					if (ImGui::Selectable(layout->GetMenuLabel().GetBuffer()))
+						RequestLayoutSwitch(*layout);
 				}
 				ImGui::EndMenu();
 			}
@@ -207,22 +207,25 @@ namespace Slush
 		myShouldBeOpen = false;
 	}
 
-	void Window::RegisterLayout(IAppLayoutFactory* aFactory)
+	void Window::AddLayout(IAppLayout* aLayout, bool aSetAsActive)
 	{
-		FW_ASSERT(aFactory, "RegisterLayout: aFactory is null");
-		myRegisteredLayouts.Add(aFactory);
+		FW_ASSERT(aLayout, "AddLayout: aLayout is null");
+		myLayouts.Add(aLayout);
+
+		if (aSetAsActive)
+			RequestLayoutSwitch(*aLayout);
 	}
 
-	void Window::RequestLayoutSwitch(IAppLayoutFactory& aFactory)
+	void Window::RequestLayoutSwitch(IAppLayout& aTarget)
 	{
 		if (!myAppLayout || !myAppLayout->HasUnsavedChanges())
 		{
-			SetAppLayout(aFactory.CreateLayout());
+			SetActiveLayout(&aTarget);
 			return;
 		}
 
 		myPendingTransition = PendingTransition::SwitchLayout;
-		myPendingLayoutFactory = &aFactory;
+		myPendingLayoutTarget = &aTarget;
 	}
 
 	void Window::UpdatePendingClose()
@@ -247,7 +250,7 @@ namespace Slush
 			break;
 		case IAppLayout::CloseRequestResult::Cancelled:
 			myPendingTransition = PendingTransition::None;
-			myPendingLayoutFactory = nullptr;
+			myPendingLayoutTarget = nullptr;
 			break;
 		case IAppLayout::CloseRequestResult::StillPending:
 			break;
@@ -257,10 +260,10 @@ namespace Slush
 	void Window::ResolvePendingTransition(const char* aCloseReason)
 	{
 		const PendingTransition transition = myPendingTransition;
-		IAppLayoutFactory* factory = myPendingLayoutFactory;
+		IAppLayout* target = myPendingLayoutTarget;
 
 		myPendingTransition = PendingTransition::None;
-		myPendingLayoutFactory = nullptr;
+		myPendingLayoutTarget = nullptr;
 
 		switch (transition)
 		{
@@ -268,8 +271,8 @@ namespace Slush
 			ConfirmClose(aCloseReason);
 			break;
 		case PendingTransition::SwitchLayout:
-			FW_ASSERT(factory, "Pending layout switch resolved with no target factory");
-			SetAppLayout(factory->CreateLayout());
+			FW_ASSERT(target, "Pending layout switch resolved with no target layout");
+			SetActiveLayout(target);
 			break;
 		case PendingTransition::None:
 			break;
@@ -281,6 +284,15 @@ namespace Slush
 		SaveAppLayoutConfig();
 
 		FW_SAFE_DELETE(myAppLayout);
+
+		myAppLayout = aLayout;
+
+		LoadAppLayoutConfig();
+	}
+
+	void Window::SetActiveLayout(IAppLayout* aLayout)
+	{
+		SaveAppLayoutConfig();
 
 		myAppLayout = aLayout;
 

--- a/Solution/Engine/Graphics/Window.h
+++ b/Solution/Engine/Graphics/Window.h
@@ -8,6 +8,7 @@ namespace sf
 namespace Slush
 {
 	class IAppLayout;
+	class IAppLayoutFactory;
 	class Dockable;
 	class Renderer;
 	class Window
@@ -37,10 +38,16 @@ namespace Slush
 
 		void SetAppLayout(IAppLayout* aLayout);
 
+		// Registers aFactory with the "Layouts" menu so its layout becomes switchable at runtime. Window
+		// takes ownership - aFactory stays alive (and registered) for the Window's whole lifetime, unlike
+		// the IAppLayout instances it creates on each switch.
+		void RegisterLayout(IAppLayoutFactory* aFactory);
+
 		void UpdateAppLayout();
 		void RenderAppLayout();
 
-		// Called every frame (from Engine::Run()) while a close is pending, until it's resolved or cancelled.
+		// Called every frame (from Engine::Run()) while a close or a menu-driven layout switch is pending,
+		// until it's resolved or cancelled.
 		void UpdatePendingClose();
 
 		sf::RenderWindow* GetRenderWindow() const { return myRenderWindow; }
@@ -59,6 +66,13 @@ namespace Slush
 		// a graceful shutdown - useful for telling it apart from a crash or a forcibly-killed process.
 		void ConfirmClose(const char* aReason);
 
+		void RequestLayoutSwitch(IAppLayoutFactory& aFactory);
+
+		// Common resolution for both a pending close and a pending layout switch, once the current
+		// layout's RequestClose() reports Resolved (or there was never a layout to check). aCloseReason
+		// is only used for the Close case - passed straight through to ConfirmClose().
+		void ResolvePendingTransition(const char* aCloseReason);
+
 		Vector2f GetSizeThatRespectsAspectRatio(int aWidth, int aHeight) const;
 
 		Rectf myWindowRect;
@@ -69,9 +83,17 @@ namespace Slush
 		sf::RenderWindow* myRenderWindow = nullptr;
 		Renderer* myRenderer = nullptr;
 		bool myShouldBeOpen = true;
-		bool myCloseRequested = false;
 		bool myDisplayImGUIDemo = false;
 		bool myScreenshotRequested = false;
 		IAppLayout* myAppLayout = nullptr;
+
+		// A close and a menu-driven layout switch both go through this same pending-transition flow, so
+		// either one gets gated by the current layout's own unsaved-changes confirmation instead of
+		// discarding silently - see UpdatePendingClose()/ResolvePendingTransition().
+		enum class PendingTransition { None, Close, SwitchLayout };
+		PendingTransition myPendingTransition = PendingTransition::None;
+		IAppLayoutFactory* myPendingLayoutFactory = nullptr;
+
+		FW_GrowingArray<IAppLayoutFactory*> myRegisteredLayouts;
 	};
 }

--- a/Solution/Engine/Graphics/Window.h
+++ b/Solution/Engine/Graphics/Window.h
@@ -8,7 +8,6 @@ namespace sf
 namespace Slush
 {
 	class IAppLayout;
-	class IAppLayoutFactory;
 	class Dockable;
 	class Renderer;
 	class Window
@@ -38,10 +37,11 @@ namespace Slush
 
 		void SetAppLayout(IAppLayout* aLayout);
 
-		// Registers aFactory with the "Layouts" menu so its layout becomes switchable at runtime. Window
-		// takes ownership - aFactory stays alive (and registered) for the Window's whole lifetime, unlike
-		// the IAppLayout instances it creates on each switch.
-		void RegisterLayout(IAppLayoutFactory* aFactory);
+		// Adds aLayout to the "Layouts" menu so it becomes switchable at runtime. Window takes ownership -
+		// aLayout stays alive for the Window's whole lifetime and switching the active layout never
+		// deletes or recreates it, unlike SetAppLayout(). Pass aSetAsActive to make it the active layout
+		// immediately (subject to the same unsaved-changes gating as a menu-driven switch).
+		void AddLayout(IAppLayout* aLayout, bool aSetAsActive = false);
 
 		void UpdateAppLayout();
 		void RenderAppLayout();
@@ -66,7 +66,11 @@ namespace Slush
 		// a graceful shutdown - useful for telling it apart from a crash or a forcibly-killed process.
 		void ConfirmClose(const char* aReason);
 
-		void RequestLayoutSwitch(IAppLayoutFactory& aFactory);
+		// Switches the active layout among Window-owned myLayouts entries - never deletes anything, unlike
+		// SetAppLayout().
+		void SetActiveLayout(IAppLayout* aLayout);
+
+		void RequestLayoutSwitch(IAppLayout& aTarget);
 
 		// Common resolution for both a pending close and a pending layout switch, once the current
 		// layout's RequestClose() reports Resolved (or there was never a layout to check). aCloseReason
@@ -92,8 +96,10 @@ namespace Slush
 		// discarding silently - see UpdatePendingClose()/ResolvePendingTransition().
 		enum class PendingTransition { None, Close, SwitchLayout };
 		PendingTransition myPendingTransition = PendingTransition::None;
-		IAppLayoutFactory* myPendingLayoutFactory = nullptr;
+		IAppLayout* myPendingLayoutTarget = nullptr;
 
-		FW_GrowingArray<IAppLayoutFactory*> myRegisteredLayouts;
+		// Layouts added via AddLayout() - owned by Window for its whole lifetime, distinct from a layout
+		// set directly via SetAppLayout() (which Window deletes on the next switch/destruction instead).
+		FW_GrowingArray<IAppLayout*> myLayouts;
 	};
 }

--- a/Solution/TopDownGame/Level/Level.cpp
+++ b/Solution/TopDownGame/Level/Level.cpp
@@ -15,6 +15,11 @@ Navmesh& Level::GetNavmesh()
 	return myLevelData->myNavmeshData.Get()->myNavmesh;
 }
 
+NavmeshData& Level::GetNavmeshDataAsset()
+{
+	return *myLevelData->myNavmeshData.Get();
+}
+
 void Level::Update()
 {
 	GetNavmesh().Update();

--- a/Solution/TopDownGame/Level/Level.h
+++ b/Solution/TopDownGame/Level/Level.h
@@ -11,6 +11,7 @@ public:
 
 	Navmesh& GetNavmesh();
 	NavmeshData& GetNavmeshDataAsset();
+	LevelData& GetLevelDataAsset() { return *myLevelData; }
 
 	void Update();
 	void Render();

--- a/Solution/TopDownGame/Level/Level.h
+++ b/Solution/TopDownGame/Level/Level.h
@@ -10,6 +10,7 @@ public:
 	Level();
 
 	Navmesh& GetNavmesh();
+	NavmeshData& GetNavmeshDataAsset();
 
 	void Update();
 	void Render();

--- a/Solution/TopDownGame/LevelEditorDockable.cpp
+++ b/Solution/TopDownGame/LevelEditorDockable.cpp
@@ -3,6 +3,7 @@
 #include "LevelEditorDockable.h"
 
 #include "Level/Level.h"
+#include "Level/LevelData.h"
 #include "Level/NavmeshData.h"
 
 #include "Core/CommandLineArgs.h"
@@ -23,6 +24,7 @@ void LevelEditorDockable::RenderOverlay() const
 {
 	RenderBoxCutPreview();
 	RenderManualCutPreview();
+	RenderStartAndGoalMarkers();
 }
 
 void LevelEditorDockable::RenderBoxCutPreview() const
@@ -62,10 +64,26 @@ void LevelEditorDockable::RenderManualCutPreview() const
 	renderer.RenderLine(myCutPositions.GetLast(), mousePos, cutPreviewColor);
 }
 
+void LevelEditorDockable::RenderStartAndGoalMarkers() const
+{
+	Slush::Engine& engine = Slush::Engine::GetInstance();
+	Slush::Renderer& renderer = engine.GetWindow().GetRenderer();
+	const LevelData& levelData = myLevel.GetLevelDataAsset();
+
+	const float markerRadius = 10.f;
+	const int startColor = 0xFF00FF00;
+	const int goalColor = 0xFF0000FF;
+
+	renderer.RenderCircle(levelData.myStartPosition, markerRadius, startColor);
+	renderer.RenderCircle(levelData.myGoalPosition, markerRadius, goalColor);
+}
+
 void LevelEditorDockable::OnUpdate()
 {
 	UpdateBoxCutMode();
 	UpdateManualCutMode();
+	UpdateSetStartMode();
+	UpdateSetGoalMode();
 }
 
 void LevelEditorDockable::UpdateBoxCutMode()
@@ -116,6 +134,30 @@ void LevelEditorDockable::UpdateManualCutMode()
 	}
 }
 
+void LevelEditorDockable::UpdateSetStartMode()
+{
+	if (!myIsSetStartModeActive)
+		return;
+
+	Slush::Engine& engine = Slush::Engine::GetInstance();
+	if (!engine.GetInput().WasMouseReleased(Slush::Input::LEFTMB))
+		return;
+
+	SetStartPosition(engine.GetInput().GetMousePositionf());
+}
+
+void LevelEditorDockable::UpdateSetGoalMode()
+{
+	if (!myIsSetGoalModeActive)
+		return;
+
+	Slush::Engine& engine = Slush::Engine::GetInstance();
+	if (!engine.GetInput().WasMouseReleased(Slush::Input::LEFTMB))
+		return;
+
+	SetGoalPosition(engine.GetInput().GetMousePositionf());
+}
+
 void LevelEditorDockable::CutNavmeshHole(const FW_GrowingArray<Vector2f>& someCutPositions)
 {
 	NavmeshData& navmeshData = myLevel.GetNavmeshDataAsset();
@@ -123,6 +165,24 @@ void LevelEditorDockable::CutNavmeshHole(const FW_GrowingArray<Vector2f>& someCu
 	Slush::AssetEditScope editScope(navmeshData);
 	navmeshData.myNavmesh.CutHole(someCutPositions);
 	navmeshData.MarkAsUnsaved();
+}
+
+void LevelEditorDockable::SetStartPosition(const Vector2f& aPosition)
+{
+	LevelData& levelData = myLevel.GetLevelDataAsset();
+
+	Slush::AssetEditScope editScope(levelData);
+	levelData.myStartPosition = aPosition;
+	levelData.MarkAsUnsaved();
+}
+
+void LevelEditorDockable::SetGoalPosition(const Vector2f& aPosition)
+{
+	LevelData& levelData = myLevel.GetLevelDataAsset();
+
+	Slush::AssetEditScope editScope(levelData);
+	levelData.myGoalPosition = aPosition;
+	levelData.MarkAsUnsaved();
 }
 
 void LevelEditorDockable::DisableBoxCutMode()
@@ -141,6 +201,16 @@ void LevelEditorDockable::DisableManualCutMode()
 
 	myIsManualCutModeActive = false;
 	myCutPositions.RemoveAll();
+}
+
+void LevelEditorDockable::DisableSetStartMode()
+{
+	myIsSetStartModeActive = false;
+}
+
+void LevelEditorDockable::DisableSetGoalMode()
+{
+	myIsSetGoalModeActive = false;
 }
 
 void LevelEditorDockable::OnBuildUI()
@@ -168,6 +238,8 @@ void LevelEditorDockable::OnBuildUI()
 			myBoxCutHasStartCorner = false;
 
 			DisableManualCutMode();
+			DisableSetStartMode();
+			DisableSetGoalMode();
 		}
 	}
 
@@ -184,22 +256,63 @@ void LevelEditorDockable::OnBuildUI()
 			myCutPositions.RemoveAll();
 
 			DisableBoxCutMode();
+			DisableSetStartMode();
+			DisableSetGoalMode();
+		}
+	}
+
+	if (myIsSetStartModeActive)
+	{
+		if (ImGui::Button("Disable Set Start"))
+			DisableSetStartMode();
+	}
+	else
+	{
+		if (ImGui::Button("Enable Set Start"))
+		{
+			myIsSetStartModeActive = true;
+
+			DisableBoxCutMode();
+			DisableManualCutMode();
+			DisableSetGoalMode();
+		}
+	}
+
+	if (myIsSetGoalModeActive)
+	{
+		if (ImGui::Button("Disable Set Goal"))
+			DisableSetGoalMode();
+	}
+	else
+	{
+		if (ImGui::Button("Enable Set Goal"))
+		{
+			myIsSetGoalModeActive = true;
+
+			DisableBoxCutMode();
+			DisableManualCutMode();
+			DisableSetStartMode();
 		}
 	}
 }
 
 bool LevelEditorDockable::HasUnsavedChanges() const
 {
-	return myLevel.GetNavmeshDataAsset().HasUnsavedChanges();
+	return myLevel.GetNavmeshDataAsset().HasUnsavedChanges() || myLevel.GetLevelDataAsset().HasUnsavedChanges();
 }
 
 void LevelEditorDockable::OnCloseRequested()
 {
-	// Under -hidewindow, no user is around to click a popup - log which asset is being discarded, by
+	// Under -hidewindow, no user is around to click a popup - log which asset(s) are being discarded, by
 	// name, and resolve immediately instead of opening one that would otherwise hang the close forever.
 	if (Slush::CommandLineArgs::GetInstance().HasFlag("-hidewindow"))
 	{
-		SLUSH_ERROR("[Level Editor] Closing with unsaved changes in '%s', discarding them (-hidewindow)", myLevel.GetNavmeshDataAsset().GetAssetName().GetBuffer());
+		if (myLevel.GetNavmeshDataAsset().HasUnsavedChanges())
+			SLUSH_ERROR("[Level Editor] Closing with unsaved changes in '%s', discarding them (-hidewindow)", myLevel.GetNavmeshDataAsset().GetAssetName().GetBuffer());
+
+		if (myLevel.GetLevelDataAsset().HasUnsavedChanges())
+			SLUSH_ERROR("[Level Editor] Closing with unsaved changes in '%s', discarding them (-hidewindow)", myLevel.GetLevelDataAsset().GetAssetName().GetBuffer());
+
 		DiscardUnsavedChanges();
 		return;
 	}
@@ -217,7 +330,11 @@ void LevelEditorDockable::OnBuildModals()
 
 	if (ImGui::BeginPopupModal("Unsaved Changes", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
 	{
-		ImGui::Text("The Level Editor has unsaved changes.");
+		ImGui::Text("The following assets have unsaved changes:");
+		if (myLevel.GetNavmeshDataAsset().HasUnsavedChanges())
+			ImGui::BulletText("%s", myLevel.GetNavmeshDataAsset().GetAssetName().GetBuffer());
+		if (myLevel.GetLevelDataAsset().HasUnsavedChanges())
+			ImGui::BulletText("%s", myLevel.GetLevelDataAsset().GetAssetName().GetBuffer());
 
 		if (ImGui::Button("Save"))
 		{
@@ -250,9 +367,11 @@ void LevelEditorDockable::OnBuildModals()
 void LevelEditorDockable::SaveAssets()
 {
 	myLevel.GetNavmeshDataAsset().Save();
+	myLevel.GetLevelDataAsset().Save();
 }
 
 void LevelEditorDockable::DiscardUnsavedChanges()
 {
 	myLevel.GetNavmeshDataAsset().MarkAsSaved();
+	myLevel.GetLevelDataAsset().MarkAsSaved();
 }

--- a/Solution/TopDownGame/LevelEditorDockable.cpp
+++ b/Solution/TopDownGame/LevelEditorDockable.cpp
@@ -3,18 +3,256 @@
 #include "LevelEditorDockable.h"
 
 #include "Level/Level.h"
+#include "Level/NavmeshData.h"
+
+#include "Core/CommandLineArgs.h"
+#include "Core/Dockables/IAppLayout.h"
+#include "Core/Engine.h"
+#include "Core/Input.h"
+#include "Graphics/Renderer.h"
+#include "Graphics/Window.h"
+#include <imgui/ImGuiWidgets.h>
 
 LevelEditorDockable::LevelEditorDockable(Level& aLevel)
-	: Slush::DockableBase<LevelEditorDockable>()
+	: Slush::DockableBase<LevelEditorDockable>(true)
 	, myLevel(aLevel)
 {
 }
 
+void LevelEditorDockable::RenderOverlay() const
+{
+	RenderBoxCutPreview();
+	RenderManualCutPreview();
+}
+
+void LevelEditorDockable::RenderBoxCutPreview() const
+{
+	if (!myIsBoxCutModeActive || !myBoxCutHasStartCorner)
+		return;
+
+	Slush::Engine& engine = Slush::Engine::GetInstance();
+	Slush::Renderer& renderer = engine.GetWindow().GetRenderer();
+	const Vector2f& mousePos = engine.GetInput().GetMousePositionf();
+
+	const Vector2f topLeft{ FW_Min(myBoxCutStartCorner.x, mousePos.x), FW_Min(myBoxCutStartCorner.y, mousePos.y) };
+	const Vector2f bottomRight{ FW_Max(myBoxCutStartCorner.x, mousePos.x), FW_Max(myBoxCutStartCorner.y, mousePos.y) };
+	const Vector2f topRight{ bottomRight.x, topLeft.y };
+	const Vector2f bottomLeft{ topLeft.x, bottomRight.y };
+
+	const int boxPreviewColor = 0xFF00FF00;
+	renderer.RenderLine(topLeft, topRight, boxPreviewColor);
+	renderer.RenderLine(topRight, bottomRight, boxPreviewColor);
+	renderer.RenderLine(bottomRight, bottomLeft, boxPreviewColor);
+	renderer.RenderLine(bottomLeft, topLeft, boxPreviewColor);
+}
+
+void LevelEditorDockable::RenderManualCutPreview() const
+{
+	if (!myIsManualCutModeActive || myCutPositions.IsEmpty())
+		return;
+
+	Slush::Engine& engine = Slush::Engine::GetInstance();
+	Slush::Renderer& renderer = engine.GetWindow().GetRenderer();
+	const Vector2f& mousePos = engine.GetInput().GetMousePositionf();
+
+	const int cutPreviewColor = 0xFF000000;
+	for (int i = 0; i < myCutPositions.Count() - 1; ++i)
+		renderer.RenderLine(myCutPositions[i], myCutPositions[i + 1], cutPreviewColor);
+
+	renderer.RenderLine(myCutPositions.GetLast(), mousePos, cutPreviewColor);
+}
+
 void LevelEditorDockable::OnUpdate()
 {
+	UpdateBoxCutMode();
+	UpdateManualCutMode();
+}
+
+void LevelEditorDockable::UpdateBoxCutMode()
+{
+	if (!myIsBoxCutModeActive)
+		return;
+
+	Slush::Engine& engine = Slush::Engine::GetInstance();
+	if (!engine.GetInput().WasMouseReleased(Slush::Input::LEFTMB))
+		return;
+
+	if (!myBoxCutHasStartCorner)
+	{
+		myBoxCutStartCorner = engine.GetInput().GetMousePositionf();
+		myBoxCutHasStartCorner = true;
+		return;
+	}
+
+	const Vector2f endCorner = engine.GetInput().GetMousePositionf();
+	myBoxCutHasStartCorner = false;
+
+	const Vector2f topLeft{ FW_Min(myBoxCutStartCorner.x, endCorner.x), FW_Min(myBoxCutStartCorner.y, endCorner.y) };
+	const Vector2f bottomRight{ FW_Max(myBoxCutStartCorner.x, endCorner.x), FW_Max(myBoxCutStartCorner.y, endCorner.y) };
+
+	FW_GrowingArray<Vector2f> boxCorners;
+	boxCorners.Add(topLeft);
+	boxCorners.Add(Vector2f{ bottomRight.x, topLeft.y });
+	boxCorners.Add(bottomRight);
+	boxCorners.Add(Vector2f{ topLeft.x, bottomRight.y });
+
+	CutNavmeshHole(boxCorners);
+}
+
+void LevelEditorDockable::UpdateManualCutMode()
+{
+	if (!myIsManualCutModeActive)
+		return;
+
+	Slush::Engine& engine = Slush::Engine::GetInstance();
+	if (engine.GetInput().WasMouseReleased(Slush::Input::LEFTMB))
+	{
+		myCutPositions.Add(engine.GetInput().GetMousePositionf());
+	}
+	else if (engine.GetInput().WasMouseReleased(Slush::Input::RIGHTMB))
+	{
+		CutNavmeshHole(myCutPositions);
+		myCutPositions.RemoveAll();
+	}
+}
+
+void LevelEditorDockable::CutNavmeshHole(const FW_GrowingArray<Vector2f>& someCutPositions)
+{
+	NavmeshData& navmeshData = myLevel.GetNavmeshDataAsset();
+
+	Slush::AssetEditScope editScope(navmeshData);
+	navmeshData.myNavmesh.CutHole(someCutPositions);
+	navmeshData.MarkAsUnsaved();
+}
+
+void LevelEditorDockable::DisableBoxCutMode()
+{
+	if (!myIsBoxCutModeActive)
+		return;
+
+	myIsBoxCutModeActive = false;
+	myBoxCutHasStartCorner = false;
+}
+
+void LevelEditorDockable::DisableManualCutMode()
+{
+	if (!myIsManualCutModeActive)
+		return;
+
+	myIsManualCutModeActive = false;
+	myCutPositions.RemoveAll();
 }
 
 void LevelEditorDockable::OnBuildUI()
 {
+	if (ImGui::BeginMenuBar())
+	{
+		if (ImGui::MenuItem("Save"))
+			SaveAssets();
+
+		ImGui::EndMenuBar();
+	}
+
 	ImGui::Text("Level Editor");
+
+	if (myIsBoxCutModeActive)
+	{
+		if (ImGui::Button("Disable Box Cut"))
+			DisableBoxCutMode();
+	}
+	else
+	{
+		if (ImGui::Button("Enable Box Cut"))
+		{
+			myIsBoxCutModeActive = true;
+			myBoxCutHasStartCorner = false;
+
+			DisableManualCutMode();
+		}
+	}
+
+	if (myIsManualCutModeActive)
+	{
+		if (ImGui::Button("Disable Manual Cut"))
+			DisableManualCutMode();
+	}
+	else
+	{
+		if (ImGui::Button("Enable Manual Cut"))
+		{
+			myIsManualCutModeActive = true;
+			myCutPositions.RemoveAll();
+
+			DisableBoxCutMode();
+		}
+	}
+}
+
+bool LevelEditorDockable::HasUnsavedChanges() const
+{
+	return myLevel.GetNavmeshDataAsset().HasUnsavedChanges();
+}
+
+void LevelEditorDockable::OnCloseRequested()
+{
+	// Under -hidewindow, no user is around to click a popup - log which asset is being discarded, by
+	// name, and resolve immediately instead of opening one that would otherwise hang the close forever.
+	if (Slush::CommandLineArgs::GetInstance().HasFlag("-hidewindow"))
+	{
+		SLUSH_ERROR("[Level Editor] Closing with unsaved changes in '%s', discarding them (-hidewindow)", myLevel.GetNavmeshDataAsset().GetAssetName().GetBuffer());
+		DiscardUnsavedChanges();
+		return;
+	}
+
+	myWantToOpenUnsavedChangesPopup = true;
+}
+
+void LevelEditorDockable::OnBuildModals()
+{
+	if (myWantToOpenUnsavedChangesPopup)
+	{
+		ImGui::OpenPopup("Unsaved Changes");
+		myWantToOpenUnsavedChangesPopup = false;
+	}
+
+	if (ImGui::BeginPopupModal("Unsaved Changes", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+	{
+		ImGui::Text("The Level Editor has unsaved changes.");
+
+		if (ImGui::Button("Save"))
+		{
+			SaveAssets();
+			ImGui::CloseCurrentPopup();
+		}
+
+		ImGui::SameLine();
+
+		if (ImGui::Button("Discard"))
+		{
+			DiscardUnsavedChanges();
+			ImGui::CloseCurrentPopup();
+		}
+
+		ImGui::SameLine();
+
+		if (ImGui::Button("Cancel"))
+		{
+			if (myOwnerLayout)
+				myOwnerLayout->CancelCloseRequest();
+
+			ImGui::CloseCurrentPopup();
+		}
+
+		ImGui::EndPopup();
+	}
+}
+
+void LevelEditorDockable::SaveAssets()
+{
+	myLevel.GetNavmeshDataAsset().Save();
+}
+
+void LevelEditorDockable::DiscardUnsavedChanges()
+{
+	myLevel.GetNavmeshDataAsset().MarkAsSaved();
 }

--- a/Solution/TopDownGame/LevelEditorDockable.cpp
+++ b/Solution/TopDownGame/LevelEditorDockable.cpp
@@ -1,0 +1,20 @@
+#include "stdafx.h"
+
+#include "LevelEditorDockable.h"
+
+#include "Level/Level.h"
+
+LevelEditorDockable::LevelEditorDockable(Level& aLevel)
+	: Slush::DockableBase<LevelEditorDockable>()
+	, myLevel(aLevel)
+{
+}
+
+void LevelEditorDockable::OnUpdate()
+{
+}
+
+void LevelEditorDockable::OnBuildUI()
+{
+	ImGui::Text("Level Editor");
+}

--- a/Solution/TopDownGame/LevelEditorDockable.h
+++ b/Solution/TopDownGame/LevelEditorDockable.h
@@ -11,10 +11,42 @@ public:
 
 	const char* GetName() const override { return "Level Editor"; }
 
+	void RenderOverlay() const;
+
 protected:
 	void OnUpdate() override;
 	void OnBuildUI() override;
 
+	bool HasUnsavedChanges() const override;
+	void OnCloseRequested() override;
+	void OnBuildModals() override;
+
 private:
+	void UpdateBoxCutMode();
+	void UpdateManualCutMode();
+
+	void RenderBoxCutPreview() const;
+	void RenderManualCutPreview() const;
+
+	void DisableBoxCutMode();
+	void DisableManualCutMode();
+
+	// Shared by both cut modes - wraps the CutHole() call in an AssetEditScope and marks the NavmeshData
+	// asset dirty, since CutHole() itself is a direct field write, not one of the ImGuiWidgets:: calls
+	// that would otherwise mark it dirty automatically.
+	void CutNavmeshHole(const FW_GrowingArray<Vector2f>& someCutPositions);
+
+	void SaveAssets();
+	void DiscardUnsavedChanges();
+
 	Level& myLevel;
+
+	bool myIsBoxCutModeActive = false;
+	bool myBoxCutHasStartCorner = false;
+	Vector2f myBoxCutStartCorner;
+
+	bool myIsManualCutModeActive = false;
+	FW_GrowingArray<Vector2f> myCutPositions;
+
+	bool myWantToOpenUnsavedChangesPopup = false;
 };

--- a/Solution/TopDownGame/LevelEditorDockable.h
+++ b/Solution/TopDownGame/LevelEditorDockable.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Core/Dockables/Dockable.h>
+
+class Level;
+
+class LevelEditorDockable : public Slush::DockableBase<LevelEditorDockable>
+{
+public:
+	LevelEditorDockable(Level& aLevel);
+
+	const char* GetName() const override { return "Level Editor"; }
+
+protected:
+	void OnUpdate() override;
+	void OnBuildUI() override;
+
+private:
+	Level& myLevel;
+};

--- a/Solution/TopDownGame/LevelEditorDockable.h
+++ b/Solution/TopDownGame/LevelEditorDockable.h
@@ -24,17 +24,26 @@ protected:
 private:
 	void UpdateBoxCutMode();
 	void UpdateManualCutMode();
+	void UpdateSetStartMode();
+	void UpdateSetGoalMode();
 
 	void RenderBoxCutPreview() const;
 	void RenderManualCutPreview() const;
+	void RenderStartAndGoalMarkers() const;
 
 	void DisableBoxCutMode();
 	void DisableManualCutMode();
+	void DisableSetStartMode();
+	void DisableSetGoalMode();
 
 	// Shared by both cut modes - wraps the CutHole() call in an AssetEditScope and marks the NavmeshData
 	// asset dirty, since CutHole() itself is a direct field write, not one of the ImGuiWidgets:: calls
 	// that would otherwise mark it dirty automatically.
 	void CutNavmeshHole(const FW_GrowingArray<Vector2f>& someCutPositions);
+
+	// Same idea for the single-point spawn/goal writes, against the LevelData asset instead.
+	void SetStartPosition(const Vector2f& aPosition);
+	void SetGoalPosition(const Vector2f& aPosition);
 
 	void SaveAssets();
 	void DiscardUnsavedChanges();
@@ -47,6 +56,9 @@ private:
 
 	bool myIsManualCutModeActive = false;
 	FW_GrowingArray<Vector2f> myCutPositions;
+
+	bool myIsSetStartModeActive = false;
+	bool myIsSetGoalModeActive = false;
 
 	bool myWantToOpenUnsavedChangesPopup = false;
 };

--- a/Solution/TopDownGame/LevelEditorLayout.cpp
+++ b/Solution/TopDownGame/LevelEditorLayout.cpp
@@ -25,7 +25,7 @@ void LevelEditorLayout::OnRender()
 	Slush::Engine& engine = Slush::Engine::GetInstance();
 	engine.GetWindow().GetRenderer().StartOffscreenBuffer();
 
-	// Terrain-shape (Phase 3) and spawn/goal (Phase 4) overlay rendering land here.
+	myLevelEditorDockable->RenderOverlay();
 
 	engine.GetWindow().GetRenderer().EndOffscreenBuffer();
 }

--- a/Solution/TopDownGame/LevelEditorLayout.cpp
+++ b/Solution/TopDownGame/LevelEditorLayout.cpp
@@ -1,0 +1,31 @@
+#include "stdafx.h"
+
+#include "LevelEditorLayout.h"
+
+#include "LevelEditorDockable.h"
+#include "Level/Level.h"
+
+#include "Core/Engine.h"
+#include "Core/Dockables/GameViewDockable.h"
+#include "Graphics/Window.h"
+#include "Graphics/Renderer.h"
+
+LevelEditorLayout::LevelEditorLayout(Level& aLevel)
+	: Slush::IAppLayout("LevelEditor")
+	, myLevel(aLevel)
+{
+	AddDockable(new Slush::GameViewDockable());
+
+	myLevelEditorDockable = new LevelEditorDockable(aLevel);
+	AddDockable(myLevelEditorDockable);
+}
+
+void LevelEditorLayout::OnRender()
+{
+	Slush::Engine& engine = Slush::Engine::GetInstance();
+	engine.GetWindow().GetRenderer().StartOffscreenBuffer();
+
+	// Terrain-shape (Phase 3) and spawn/goal (Phase 4) overlay rendering land here.
+
+	engine.GetWindow().GetRenderer().EndOffscreenBuffer();
+}

--- a/Solution/TopDownGame/LevelEditorLayout.cpp
+++ b/Solution/TopDownGame/LevelEditorLayout.cpp
@@ -11,7 +11,7 @@
 #include "Graphics/Renderer.h"
 
 LevelEditorLayout::LevelEditorLayout(Level& aLevel)
-	: Slush::IAppLayout("LevelEditor")
+	: Slush::IAppLayout("LevelEditor", "Level Editor")
 	, myLevel(aLevel)
 {
 	AddDockable(new Slush::GameViewDockable());

--- a/Solution/TopDownGame/LevelEditorLayout.cpp
+++ b/Solution/TopDownGame/LevelEditorLayout.cpp
@@ -25,6 +25,7 @@ void LevelEditorLayout::OnRender()
 	Slush::Engine& engine = Slush::Engine::GetInstance();
 	engine.GetWindow().GetRenderer().StartOffscreenBuffer();
 
+	myLevel.Render();
 	myLevelEditorDockable->RenderOverlay();
 
 	engine.GetWindow().GetRenderer().EndOffscreenBuffer();

--- a/Solution/TopDownGame/LevelEditorLayout.h
+++ b/Solution/TopDownGame/LevelEditorLayout.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Core/Dockables/IAppLayout.h>
+
+class Level;
+class LevelEditorDockable;
+
+class LevelEditorLayout : public Slush::IAppLayout
+{
+public:
+	LevelEditorLayout(Level& aLevel);
+
+protected:
+	void OnRender() override;
+
+private:
+	Level& myLevel;
+	LevelEditorDockable* myLevelEditorDockable = nullptr;
+};

--- a/Solution/TopDownGame/NavmeshDebuggingLayout.cpp
+++ b/Solution/TopDownGame/NavmeshDebuggingLayout.cpp
@@ -25,6 +25,7 @@ void NavmeshDebuggingLayout::OnRender()
 	Slush::Engine& engine = Slush::Engine::GetInstance();
 	engine.GetWindow().GetRenderer().StartOffscreenBuffer();
 
+	myNavmesh.Render();
 	myNavmeshDebuggerDockable->RenderDebugOverlay();
 
 	engine.GetWindow().GetRenderer().EndOffscreenBuffer();

--- a/Solution/TopDownGame/NavmeshDebuggingLayout.cpp
+++ b/Solution/TopDownGame/NavmeshDebuggingLayout.cpp
@@ -9,10 +9,11 @@
 #include "Graphics/Window.h"
 #include "Graphics/Renderer.h"
 
-NavmeshDebuggingLayout::NavmeshDebuggingLayout(Navmesh& aNavmesh)
+NavmeshDebuggingLayout::NavmeshDebuggingLayout()
 	: Slush::IAppLayout("TopDownGame")
-	, myNavmesh(aNavmesh)
 {
+	myNavmesh.GenerateDefaultGrid();
+
 	AddDockable(new Slush::GameViewDockable());
 
 	myNavmeshDebuggerDockable = new NavmeshDebuggerDockable(myNavmesh);

--- a/Solution/TopDownGame/NavmeshDebuggingLayout.cpp
+++ b/Solution/TopDownGame/NavmeshDebuggingLayout.cpp
@@ -10,7 +10,7 @@
 #include "Graphics/Renderer.h"
 
 NavmeshDebuggingLayout::NavmeshDebuggingLayout()
-	: Slush::IAppLayout("TopDownGame")
+	: Slush::IAppLayout("TopDownGame", "Navmesh Debugger")
 {
 	myNavmesh.GenerateDefaultGrid();
 

--- a/Solution/TopDownGame/NavmeshDebuggingLayout.h
+++ b/Solution/TopDownGame/NavmeshDebuggingLayout.h
@@ -2,18 +2,22 @@
 
 #include <Core/Dockables/IAppLayout.h>
 
-class Navmesh;
+#include "Navmesh.h"
+
 class NavmeshDebuggerDockable;
 
 class NavmeshDebuggingLayout : public Slush::IAppLayout
 {
 public:
-	NavmeshDebuggingLayout(Navmesh& aNavmesh);
+	NavmeshDebuggingLayout();
 
 protected:
 	void OnRender() override;
 
 private:
-	Navmesh& myNavmesh;
+	// Owned outright rather than referencing the real Level's NavmeshData - this layout is a pure
+	// diagnostic sandbox for quick pathfinding experiments, kept fully separate from the real,
+	// persisted navmesh the Level Editor saves.
+	Navmesh myNavmesh;
 	NavmeshDebuggerDockable* myNavmeshDebuggerDockable = nullptr;
 };

--- a/Solution/TopDownGame/TopDownGame.vcxproj
+++ b/Solution/TopDownGame/TopDownGame.vcxproj
@@ -146,6 +146,8 @@
     <ClCompile Include="NavmeshTestSuite.cpp" />
     <ClCompile Include="NavmeshDebuggerDockable.cpp" />
     <ClCompile Include="NavmeshDebuggingLayout.cpp" />
+    <ClCompile Include="LevelEditorDockable.cpp" />
+    <ClCompile Include="LevelEditorLayout.cpp" />
     <ClCompile Include="Level\NavmeshData.cpp" />
     <ClCompile Include="Level\LevelData.cpp" />
     <ClCompile Include="Level\Level.cpp" />
@@ -159,6 +161,8 @@
     <ClInclude Include="NavmeshTestSuite.h" />
     <ClInclude Include="NavmeshDebuggerDockable.h" />
     <ClInclude Include="NavmeshDebuggingLayout.h" />
+    <ClInclude Include="LevelEditorDockable.h" />
+    <ClInclude Include="LevelEditorLayout.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="Level\NavmeshData.h" />
     <ClInclude Include="Level\LevelData.h" />

--- a/Solution/TopDownGame/TopDownGame.vcxproj.filters
+++ b/Solution/TopDownGame/TopDownGame.vcxproj.filters
@@ -7,6 +7,8 @@
     <ClCompile Include="NavmeshTestSuite.cpp" />
     <ClCompile Include="NavmeshDebuggerDockable.cpp" />
     <ClCompile Include="NavmeshDebuggingLayout.cpp" />
+    <ClCompile Include="LevelEditorDockable.cpp" />
+    <ClCompile Include="LevelEditorLayout.cpp" />
     <ClCompile Include="Level\NavmeshData.cpp" />
     <ClCompile Include="Level\LevelData.cpp" />
     <ClCompile Include="Level\Level.cpp" />
@@ -17,6 +19,8 @@
     <ClInclude Include="NavmeshTestSuite.h" />
     <ClInclude Include="NavmeshDebuggerDockable.h" />
     <ClInclude Include="NavmeshDebuggingLayout.h" />
+    <ClInclude Include="LevelEditorDockable.h" />
+    <ClInclude Include="LevelEditorLayout.h" />
     <ClInclude Include="Level\NavmeshData.h" />
     <ClInclude Include="Level\LevelData.h" />
     <ClInclude Include="Level\Level.h" />

--- a/Solution/TopDownGame/main.cpp
+++ b/Solution/TopDownGame/main.cpp
@@ -15,29 +15,6 @@
 #include "NavmeshDebuggingLayout.h"
 #include "LevelEditorLayout.h"
 
-// Lets Window's "Layouts" menu (re)create a NavmeshDebuggingLayout on demand. NavmeshDebuggingLayout
-// owns its own throwaway Navmesh (a default grid, not the real Level's), so this factory needs no
-// state of its own.
-class NavmeshDebuggingLayoutFactory : public Slush::IAppLayoutFactory
-{
-public:
-	const char* GetMenuLabel() const override { return "Navmesh Debugger"; }
-	Slush::IAppLayout* CreateLayout() const override { return new NavmeshDebuggingLayout(); }
-};
-
-// Same idea for LevelEditorLayout - myLevel is the same App-owned Level referenced above.
-class LevelEditorLayoutFactory : public Slush::IAppLayoutFactory
-{
-public:
-	explicit LevelEditorLayoutFactory(Level& aLevel) : myLevel(aLevel) {}
-
-	const char* GetMenuLabel() const override { return "Level Editor"; }
-	Slush::IAppLayout* CreateLayout() const override { return new LevelEditorLayout(myLevel); }
-
-private:
-	Level& myLevel;
-};
-
 class App : public Slush::IApp
 {
 public:
@@ -51,9 +28,8 @@ public:
 		myLevel = new Level();
 
 		Slush::Window& window = Slush::Engine::GetInstance().GetWindow();
-		window.RegisterLayout(new NavmeshDebuggingLayoutFactory());
-		window.RegisterLayout(new LevelEditorLayoutFactory(*myLevel));
-		window.SetAppLayout(new LevelEditorLayout(*myLevel));
+		window.AddLayout(new NavmeshDebuggingLayout());
+		window.AddLayout(new LevelEditorLayout(*myLevel), true);
 	}
 
 	void Shutdown() override

--- a/Solution/TopDownGame/main.cpp
+++ b/Solution/TopDownGame/main.cpp
@@ -5,7 +5,6 @@
 #include "Core/CommandLineArgs.h"
 #include "Core/Engine.h"
 #include "Graphics/Window.h"
-#include "Graphics/Renderer.h"
 #include "Core/Input.h"
 
 #include "Level/Level.h"
@@ -70,16 +69,6 @@ public:
 			engine.GetWindow().Close();
 
 		myLevel->Update();
-	}
-
-	void Render() override
-	{
-		Slush::Renderer& renderer = Slush::Engine::GetInstance().GetWindow().GetRenderer();
-		renderer.StartOffscreenBuffer();
-
-		myLevel->Render();
-
-		renderer.EndOffscreenBuffer();
 	}
 
 private:

--- a/Solution/TopDownGame/main.cpp
+++ b/Solution/TopDownGame/main.cpp
@@ -15,6 +15,20 @@
 #include "NavmeshTestSuite.h"
 #include "NavmeshDebuggingLayout.h"
 
+// Lets Window's "Layouts" menu (re)create a NavmeshDebuggingLayout on demand, without Window needing to
+// know it takes a Navmesh& - myNavmesh is a reference into the App-owned Level, which outlives Window.
+class NavmeshDebuggingLayoutFactory : public Slush::IAppLayoutFactory
+{
+public:
+	explicit NavmeshDebuggingLayoutFactory(Navmesh& aNavmesh) : myNavmesh(aNavmesh) {}
+
+	const char* GetMenuLabel() const override { return "Navmesh Debugger"; }
+	Slush::IAppLayout* CreateLayout() const override { return new NavmeshDebuggingLayout(myNavmesh); }
+
+private:
+	Navmesh& myNavmesh;
+};
+
 class App : public Slush::IApp
 {
 public:
@@ -28,6 +42,7 @@ public:
 		myLevel = new Level();
 
 		Slush::Window& window = Slush::Engine::GetInstance().GetWindow();
+		window.RegisterLayout(new NavmeshDebuggingLayoutFactory(myLevel->GetNavmesh()));
 		window.SetAppLayout(new NavmeshDebuggingLayout(myLevel->GetNavmesh()));
 	}
 

--- a/Solution/TopDownGame/main.cpp
+++ b/Solution/TopDownGame/main.cpp
@@ -14,6 +14,7 @@
 #include "Navmesh.h"
 #include "NavmeshTestSuite.h"
 #include "NavmeshDebuggingLayout.h"
+#include "LevelEditorLayout.h"
 
 // Lets Window's "Layouts" menu (re)create a NavmeshDebuggingLayout on demand, without Window needing to
 // know it takes a Navmesh& - myNavmesh is a reference into the App-owned Level, which outlives Window.
@@ -27,6 +28,19 @@ public:
 
 private:
 	Navmesh& myNavmesh;
+};
+
+// Same idea for LevelEditorLayout - myLevel is the same App-owned Level referenced above.
+class LevelEditorLayoutFactory : public Slush::IAppLayoutFactory
+{
+public:
+	explicit LevelEditorLayoutFactory(Level& aLevel) : myLevel(aLevel) {}
+
+	const char* GetMenuLabel() const override { return "Level Editor"; }
+	Slush::IAppLayout* CreateLayout() const override { return new LevelEditorLayout(myLevel); }
+
+private:
+	Level& myLevel;
 };
 
 class App : public Slush::IApp
@@ -43,7 +57,8 @@ public:
 
 		Slush::Window& window = Slush::Engine::GetInstance().GetWindow();
 		window.RegisterLayout(new NavmeshDebuggingLayoutFactory(myLevel->GetNavmesh()));
-		window.SetAppLayout(new NavmeshDebuggingLayout(myLevel->GetNavmesh()));
+		window.RegisterLayout(new LevelEditorLayoutFactory(*myLevel));
+		window.SetAppLayout(new LevelEditorLayout(*myLevel));
 	}
 
 	void Shutdown() override

--- a/Solution/TopDownGame/main.cpp
+++ b/Solution/TopDownGame/main.cpp
@@ -16,18 +16,14 @@
 #include "NavmeshDebuggingLayout.h"
 #include "LevelEditorLayout.h"
 
-// Lets Window's "Layouts" menu (re)create a NavmeshDebuggingLayout on demand, without Window needing to
-// know it takes a Navmesh& - myNavmesh is a reference into the App-owned Level, which outlives Window.
+// Lets Window's "Layouts" menu (re)create a NavmeshDebuggingLayout on demand. NavmeshDebuggingLayout
+// owns its own throwaway Navmesh (a default grid, not the real Level's), so this factory needs no
+// state of its own.
 class NavmeshDebuggingLayoutFactory : public Slush::IAppLayoutFactory
 {
 public:
-	explicit NavmeshDebuggingLayoutFactory(Navmesh& aNavmesh) : myNavmesh(aNavmesh) {}
-
 	const char* GetMenuLabel() const override { return "Navmesh Debugger"; }
-	Slush::IAppLayout* CreateLayout() const override { return new NavmeshDebuggingLayout(myNavmesh); }
-
-private:
-	Navmesh& myNavmesh;
+	Slush::IAppLayout* CreateLayout() const override { return new NavmeshDebuggingLayout(); }
 };
 
 // Same idea for LevelEditorLayout - myLevel is the same App-owned Level referenced above.
@@ -56,7 +52,7 @@ public:
 		myLevel = new Level();
 
 		Slush::Window& window = Slush::Engine::GetInstance().GetWindow();
-		window.RegisterLayout(new NavmeshDebuggingLayoutFactory(myLevel->GetNavmesh()));
+		window.RegisterLayout(new NavmeshDebuggingLayoutFactory());
 		window.RegisterLayout(new LevelEditorLayoutFactory(*myLevel));
 		window.SetAppLayout(new LevelEditorLayout(*myLevel));
 	}


### PR DESCRIPTION
## Description

Adds a Level Editor app layout for authoring real level data (terrain-shape cutting and single-point spawn/goal placement) and wires up the engine's "Layouts" menu to switch between it and the existing Navmesh Debugger, respecting each layout's unsaved-changes/close-confirmation flow.

Closes #61

## Agent End-of-run Summary

All 4 phases were already implemented and committed on this branch when this run picked the issue back up (a prior worker had self-reported completion prematurely, before verification and the automatic review pass had actually happened):

- Phase 1: Wire up the "Layouts" menu + generalize the close-confirmation flow to gate layout switches (`42f88b7`)
- Phase 2: Introduce the Level Editor layout and dockable skeleton, make it the default (`0098b8f`)
- Phase 3: Terrain-shape authoring (Box Cut + Manual Cut) in the Level Editor dockable (`ed51daf`)
- Phase 4: Spawn/Goal point placement (click-to-place) in the Level Editor dockable (`085ca61`)

Notable issues hit during this run, and how they were resolved:

- An apparent crash under headless (`-hidewindow`) verification turned out to be a false alarm: launching the exe with the wrong working directory broke a relative-path unit test (`NavmeshTestSuite::TestNavmeshSaveLoadRoundTrip`'s scratch file write). Reproduced identically on a pristine `main` checkout, confirming it predates this branch and isn't a real regression. Root-caused via temporary breadcrumb instrumentation, then ruled out.
- The automatic code-review pass (below) surfaced a High-severity finding: `NavmeshDebuggerDockable` (left untouched per the issue's own instruction) shared the same live `NavmeshData` object the new Level Editor now saves, so a stray debugger cut could get silently persisted with no unsaved-changes prompt ever firing — undercutting the issue's "kept fully separate" design goal. Per user instruction, fixed in `cb85f04`: `NavmeshDebuggingLayout` now owns its own throwaway `Navmesh`, seeded from `GenerateDefaultGrid()`, instead of referencing the real Level's.
- That fix introduced a rendering regression, caught by the user during the manual-test pass: the game view kept showing the *real* Level's navmesh regardless of active layout (an existing architectural quirk — `App::Render()` in `main.cpp` unconditionally rendered it every frame), so the debugger's pathfinding tests visually appeared to run against the wrong mesh. Fixed in `cc6d63f`: navmesh rendering moved into each layout's own `OnRender()` (`LevelEditorLayout` renders the real Level's, `NavmeshDebuggingLayout` renders its own); the now-empty `App::Render()` override was removed along with its stale doc-comment reference in `IApp.h`.

Automatic review-pass findings (against the issue's own stated goals, not general style):

- **High (fixed, `cb85f04`)**: `NavmeshDebuggerDockable` sharing the real Level's live `NavmeshData` — see above.
- **Low (not fixed, reported only)**: selecting the already-active layout from the "Layouts" menu still destroys and recreates it (no same-layout early-out), losing any in-progress transient state (e.g. a manual-cut in progress) with no warning. Not data-destructive, just avoidable churn.
- **Low/cosmetic (not fixed, reported only)**: Start/Goal markers render at world-origin for a level that never had them explicitly placed, since `LevelData` has no "is set" flag for either point — pre-existing schema ambiguity, not introduced by this issue, and out of scope per the issue's "matching the current schema" note.

## Manual Testing

- [x] Default boot — the game opens directly into the Level Editor layout (not Navmesh Debugger)
- [x] Box Cut — used Box Cut mode to cut a hole in the terrain
- [x] Manual Cut — used Manual Cut mode to cut another hole in the terrain
- [x] Set Start — click-placed a new Start position
- [x] Set Goal — click-placed a new Goal position
- [x] Save — clicked Save in the Level Editor's menu bar
- [x] Switch to Navmesh Debugger (clean) — opened the Layouts menu, switched to Navmesh Debugger, no unsaved-changes prompt appeared (just saved)
- [x] Debugger isolation check — cut a hole in the Navmesh Debugger's own navmesh, switched back to Level Editor via the Layouts menu — no unsaved-changes prompt fired and the debugger's cut did not show up on the real terrain
- [x] Made an unsaved edit back in Level Editor and did not save it
- [x] Unsaved prompt appears — attempting to switch to Navmesh Debugger via the Layouts menu triggered the unsaved-changes prompt
- [x] Cancel — clicking Cancel on the prompt kept the app on Level Editor with the unsaved edit still present
- [x] Discard — attempting the switch again and clicking Discard switched to Navmesh Debugger and dropped the edit
- [x] Save from prompt — switching back to Level Editor, making another edit, attempting to switch layouts, and clicking Save on the prompt saved and then switched
- [x] Round-trip — closing and relaunching `TopDownGame.exe` with no flags confirmed the saved terrain cuts and Start/Goal positions persisted correctly

## Agent Verifications

- **Phase 1**: Full solution build passes (`Solution.sln`, Debug/x86, 0 errors). `FW_UnitTestSuite`/`NavmeshTestSuite` verified passing via a correctly-invoked headless (`-hidewindow`) boot — both suites run before `Engine::Initialize()`/window creation, so a clean boot log (`Window Created` → asset loads, no assert) confirms neither suite failed.
- **Phase 2**: Same build/unit-test verification as above; headless boot log confirms the app starts into the Level Editor layout by default (no crash/assert reaching `Window Created`).
- **Phase 3**: Same build/unit-test verification; `NavmeshTestSuite`'s `CutHole`/pathfinding tests specifically re-verified passing headlessly after this run's fix commits, confirming no regression to the reused `CutHole` mechanism.
- **Phase 4**: Same build/unit-test verification headlessly.
- **Fix commits (`cb85f04`, `cc6d63f`)**: each rebuilt the full solution clean (0 errors) and was re-verified via a fresh headless boot (unit tests + `NavmeshTestSuite` pass, no assert) before committing.

Mouse-driven ImGui interaction (Box Cut, Manual Cut, click-to-place, Save, Layout switching, the unsaved-changes modal) is out of scope for the agent to drive itself per this repo's testing conventions — that's covered above by the user's own manual-test pass instead.
