### PR TITLE
Enemy roster v1: normal, fast, slow ground types

### DIFF
--- a/Solution/Engine/EntitySystem/Components/SpriteComponent.cpp
+++ b/Solution/Engine/EntitySystem/Components/SpriteComponent.cpp
@@ -204,7 +204,7 @@ namespace Slush
 				SLUSH_ERROR("%s uses a Animated SpriteComponent without a SpriteSheet-clip, expect weird first-frame texturing", myEntityPrefab.GetAssetName().GetBuffer());
 			}
 		}
-		else
+		else if (spriteData.mySpriteType != Data::None)
 		{
 			FW_ASSERT_ALWAYS("Invalid SpriteType when creating SpriteComponent");
 		}

--- a/Solution/TopDownGame/Components/HealthComponent.cpp
+++ b/Solution/TopDownGame/Components/HealthComponent.cpp
@@ -1,0 +1,36 @@
+#include "stdafx.h"
+
+#include "HealthComponent.h"
+
+#include <EntitySystem/Entity.h>
+#include <imgui/ImGuiWidgets.h>
+
+void HealthComponent::Data::OnParse(Slush::AssetParser::Handle aComponentHandle, unsigned int /*aVersion*/)
+{
+	aComponentHandle.ParseIntField("maxhealth", myMaxHealth);
+}
+
+void HealthComponent::Data::OnBuildUI()
+{
+	Slush::ImGuiWidgets::InputInt("Max Health", &myMaxHealth);
+}
+
+HealthComponent::HealthComponent(Slush::Entity& anEntity, const Slush::EntityPrefab& anEntityPrefab)
+	: Slush::Component(anEntity, anEntityPrefab)
+{
+	myCurrentHealth = anEntityPrefab.GetComponentData<HealthComponent>().myMaxHealth;
+}
+
+void HealthComponent::DealDamage(int aDamageAmount)
+{
+	if (IsDead())
+		return;
+
+	myCurrentHealth -= aDamageAmount;
+	if (myCurrentHealth <= 0)
+	{
+		myCurrentHealth = 0;
+		myEntity.OnDeath();
+		myEntity.myIsMarkedForRemoval = true;
+	}
+}

--- a/Solution/TopDownGame/Components/HealthComponent.h
+++ b/Solution/TopDownGame/Components/HealthComponent.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <EntitySystem/Component.h>
+
+class HealthComponent : public Slush::Component
+{
+public:
+	COMPONENT_HELPER("Health", "health", 1);
+
+	struct Data : public Slush::Component::BaseData
+	{
+		void OnParse(Slush::AssetParser::Handle aComponentHandle, unsigned int aVersion) override;
+		void OnBuildUI() override;
+
+		int myMaxHealth = 30;
+	};
+
+	HealthComponent(Slush::Entity& anEntity, const Slush::EntityPrefab& anEntityPrefab);
+
+	void DealDamage(int aDamageAmount);
+	bool IsDead() const { return myCurrentHealth <= 0; }
+
+private:
+	int myCurrentHealth = 0;
+};

--- a/Solution/TopDownGame/Components/MovementComponent.cpp
+++ b/Solution/TopDownGame/Components/MovementComponent.cpp
@@ -6,7 +6,7 @@
 #include <EntitySystem/Entity.h>
 #include <imgui/ImGuiWidgets.h>
 
-#include "../Level/Level.h"
+#include "Level/Level.h"
 #include "TopDownGameGlobals.h"
 
 void MovementComponent::Data::OnParse(Slush::AssetParser::Handle aComponentHandle, unsigned int /*aVersion*/)
@@ -28,8 +28,7 @@ MovementComponent::MovementComponent(Slush::Entity& anEntity, const Slush::Entit
 void MovementComponent::OnEnterWorld()
 {
 	Level& level = TopDownGameGlobals::GetInstance().GetLevel();
-	Navmesh::PathCorridor corridor;
-	const bool foundPath = level.GetNavmesh().FindPath(myEntity.myPosition, level.GetLevelDataAsset().myGoalPosition, myWaypoints, corridor);
+	const bool foundPath = level.GetNavmesh().FindPath(myEntity.myPosition, level.GetLevelDataAsset().myGoalPosition, myWaypoints);
 	if (!foundPath)
 	{
 		SLUSH_ERROR("Enemy '%s' could not find a path from the level start to its goal", myEntityPrefab.GetAssetName().GetBuffer());

--- a/Solution/TopDownGame/Components/MovementComponent.cpp
+++ b/Solution/TopDownGame/Components/MovementComponent.cpp
@@ -1,0 +1,66 @@
+#include "stdafx.h"
+
+#include "MovementComponent.h"
+
+#include <Core/Time.h>
+#include <EntitySystem/Entity.h>
+#include <imgui/ImGuiWidgets.h>
+
+#include "../Level/Level.h"
+#include "TopDownGameGlobals.h"
+
+void MovementComponent::Data::OnParse(Slush::AssetParser::Handle aComponentHandle, unsigned int /*aVersion*/)
+{
+	aComponentHandle.ParseFloatField("movespeed", myMoveSpeed);
+}
+
+void MovementComponent::Data::OnBuildUI()
+{
+	Slush::ImGuiWidgets::InputFloat("Move Speed", &myMoveSpeed);
+}
+
+MovementComponent::MovementComponent(Slush::Entity& anEntity, const Slush::EntityPrefab& anEntityPrefab)
+	: Slush::Component(anEntity, anEntityPrefab)
+{
+	myMoveSpeed = anEntityPrefab.GetComponentData<MovementComponent>().myMoveSpeed;
+}
+
+void MovementComponent::OnEnterWorld()
+{
+	Level& level = TopDownGameGlobals::GetInstance().GetLevel();
+	Navmesh::PathCorridor corridor;
+	const bool foundPath = level.GetNavmesh().FindPath(myEntity.myPosition, level.GetLevelDataAsset().myGoalPosition, myWaypoints, corridor);
+	if (!foundPath)
+	{
+		SLUSH_ERROR("Enemy '%s' could not find a path from the level start to its goal", myEntityPrefab.GetAssetName().GetBuffer());
+		myEntity.myIsMarkedForRemoval = true;
+		return;
+	}
+
+}
+
+void MovementComponent::Update()
+{
+	float remainingDistance = myMoveSpeed * Slush::Time::GetDelta();
+	while (remainingDistance > 0.f && myNextWaypointIndex < myWaypoints.Count())
+	{
+		const Vector2f toWaypoint = myWaypoints[myNextWaypointIndex] - myEntity.myPosition;
+		const float distanceToWaypoint = Length(toWaypoint);
+		if (distanceToWaypoint <= remainingDistance)
+		{
+			myEntity.myPosition = myWaypoints[myNextWaypointIndex];
+			remainingDistance -= distanceToWaypoint;
+			++myNextWaypointIndex;
+		}
+		else
+		{
+			myEntity.myPosition += GetNormalized(toWaypoint) * remainingDistance;
+			break;
+		}
+	}
+
+	if (myNextWaypointIndex == myWaypoints.Count())
+	{
+		myEntity.myIsMarkedForRemoval = true;
+	}
+}

--- a/Solution/TopDownGame/Components/MovementComponent.h
+++ b/Solution/TopDownGame/Components/MovementComponent.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <EntitySystem/Component.h>
+#include <FW_GrowingArray.h>
+
+class MovementComponent : public Slush::Component
+{
+public:
+	COMPONENT_HELPER("Movement", "movement", 1);
+
+	struct Data : public Slush::Component::BaseData
+	{
+		void OnParse(Slush::AssetParser::Handle aComponentHandle, unsigned int aVersion) override;
+		void OnBuildUI() override;
+
+		float myMoveSpeed = 100.f;
+	};
+
+	MovementComponent(Slush::Entity& anEntity, const Slush::EntityPrefab& anEntityPrefab);
+
+	void OnEnterWorld() override;
+	void Update() override;
+
+private:
+	float myMoveSpeed = 0.f;
+	FW_GrowingArray<Vector2f> myWaypoints;
+	int myNextWaypointIndex = 0;
+};

--- a/Solution/TopDownGame/EntitySystem/EntityManager.cpp
+++ b/Solution/TopDownGame/EntitySystem/EntityManager.cpp
@@ -1,0 +1,14 @@
+#include "stdafx.h"
+
+#include <EntitySystem/ComponentRegistry.h>
+#include <EntitySystem/Components/SpriteComponent.h>
+#include <EntitySystem/EntityManager.h>
+
+#include "Components/MovementComponent.h"
+
+void Slush::EntityManager::RegisterComponents()
+{
+	Slush::ComponentRegistry& registry = Slush::ComponentRegistry::GetInstance();
+	registry.RegisterComponent<Slush::SpriteComponent, Slush::SpriteComponent::Data>();
+	registry.RegisterComponent<MovementComponent, MovementComponent::Data>();
+}

--- a/Solution/TopDownGame/EntitySystem/EntityManager.cpp
+++ b/Solution/TopDownGame/EntitySystem/EntityManager.cpp
@@ -5,10 +5,12 @@
 #include <EntitySystem/EntityManager.h>
 
 #include "Components/MovementComponent.h"
+#include "Components/HealthComponent.h"
 
 void Slush::EntityManager::RegisterComponents()
 {
 	Slush::ComponentRegistry& registry = Slush::ComponentRegistry::GetInstance();
 	registry.RegisterComponent<Slush::SpriteComponent, Slush::SpriteComponent::Data>();
 	registry.RegisterComponent<MovementComponent, MovementComponent::Data>();
+	registry.RegisterComponent<HealthComponent, HealthComponent::Data>();
 }

--- a/Solution/TopDownGame/Level/Level.cpp
+++ b/Solution/TopDownGame/Level/Level.cpp
@@ -2,12 +2,23 @@
 
 #include "Level.h"
 #include <Core\Assets\AssetStorage.h>
+#include <Core\Engine.h>
+#include <Core\Input.h>
+
+#include "TopDownGameGlobals.h"
 
 Level::Level()
 {
 	myLevelData = Slush::AssetRegistry::GetInstance().GetAsset<LevelData>("level_main");
 	FW_ASSERT(myLevelData, "Level has no valid LevelData - expected a 'level_main' LevelData asset");
 	FW_ASSERT(myLevelData->myNavmeshData.Get() != nullptr, "Level's LevelData has an unresolved NavmeshData reference");
+
+	TopDownGameGlobals::GetInstance().SetLevel(this);
+}
+
+Level::~Level()
+{
+	TopDownGameGlobals::GetInstance().SetLevel(nullptr);
 }
 
 Navmesh& Level::GetNavmesh()
@@ -22,10 +33,24 @@ NavmeshData& Level::GetNavmeshDataAsset()
 
 void Level::Update()
 {
+	Slush::Engine& engine = Slush::Engine::GetInstance();
+	if (engine.GetInput().WasKeyReleased(Slush::Input::_7))
+	{
+		SpawnEnemyNormal();
+	}
+
 	GetNavmesh().Update();
+	myEntityManager.Update();
+	myEntityManager.EndFrame();
 }
 
 void Level::Render()
 {
 	GetNavmesh().Render();
+	myEntityManager.Render();
+}
+
+void Level::SpawnEnemyNormal()
+{
+	myEntityManager.CreateEntity(myLevelData->myStartPosition, "Enemy_Normal");
 }

--- a/Solution/TopDownGame/Level/Level.cpp
+++ b/Solution/TopDownGame/Level/Level.cpp
@@ -43,6 +43,14 @@ void Level::Update()
 	{
 		DamageAllEnemies();
 	}
+	if (engine.GetInput().WasKeyReleased(Slush::Input::_9))
+	{
+		SpawnEnemyFast();
+	}
+	if (engine.GetInput().WasKeyReleased(Slush::Input::_0))
+	{
+		SpawnEnemySlow();
+	}
 
 	GetNavmesh().Update();
 	myEntityManager.Update();
@@ -57,7 +65,22 @@ void Level::Render()
 
 void Level::SpawnEnemyNormal()
 {
-	myEntityManager.CreateEntity(myLevelData->myStartPosition, "Enemy_Normal");
+	SpawnEnemy("Enemy_Normal");
+}
+
+void Level::SpawnEnemyFast()
+{
+	SpawnEnemy("Enemy_Fast");
+}
+
+void Level::SpawnEnemySlow()
+{
+	SpawnEnemy("Enemy_Slow");
+}
+
+void Level::SpawnEnemy(const char* aPrefabName)
+{
+	myEntityManager.CreateEntity(myLevelData->myStartPosition, aPrefabName);
 }
 
 void Level::DamageAllEnemies()

--- a/Solution/TopDownGame/Level/Level.cpp
+++ b/Solution/TopDownGame/Level/Level.cpp
@@ -6,6 +6,7 @@
 #include <Core\Input.h>
 
 #include "TopDownGameGlobals.h"
+#include "Components/HealthComponent.h"
 
 Level::Level()
 {
@@ -38,6 +39,10 @@ void Level::Update()
 	{
 		SpawnEnemyNormal();
 	}
+	if (engine.GetInput().WasKeyReleased(Slush::Input::_8))
+	{
+		DamageAllEnemies();
+	}
 
 	GetNavmesh().Update();
 	myEntityManager.Update();
@@ -53,4 +58,20 @@ void Level::Render()
 void Level::SpawnEnemyNormal()
 {
 	myEntityManager.CreateEntity(myLevelData->myStartPosition, "Enemy_Normal");
+}
+
+void Level::DamageAllEnemies()
+{
+	FW_GrowingArray<Slush::EntityHandle> entities;
+	myEntityManager.GetAllEntities(entities);
+
+	for (const Slush::EntityHandle& handle : entities)
+	{
+		Slush::Entity* entity = handle.Get();
+		if (!entity || entity->myIsMarkedForRemoval)
+			continue;
+
+		if (HealthComponent* health = entity->GetComponent<HealthComponent>())
+			health->DealDamage(10);
+	}
 }

--- a/Solution/TopDownGame/Level/Level.h
+++ b/Solution/TopDownGame/Level/Level.h
@@ -19,6 +19,7 @@ public:
 	void Render();
 
 	void SpawnEnemyNormal();
+	void DamageAllEnemies();
 
 private:
 	LevelData* myLevelData = nullptr;

--- a/Solution/TopDownGame/Level/Level.h
+++ b/Solution/TopDownGame/Level/Level.h
@@ -19,9 +19,13 @@ public:
 	void Render();
 
 	void SpawnEnemyNormal();
+	void SpawnEnemyFast();
+	void SpawnEnemySlow();
 	void DamageAllEnemies();
 
 private:
+	void SpawnEnemy(const char* aPrefabName);
+
 	LevelData* myLevelData = nullptr;
 	Slush::EntityManager myEntityManager;
 

--- a/Solution/TopDownGame/Level/Level.h
+++ b/Solution/TopDownGame/Level/Level.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Core\Time.h>
+#include <EntitySystem\EntityManager.h>
 
 #include "LevelData.h"
 
@@ -8,6 +9,7 @@ class Level
 {
 public:
 	Level();
+	~Level();
 
 	Navmesh& GetNavmesh();
 	NavmeshData& GetNavmeshDataAsset();
@@ -16,8 +18,11 @@ public:
 	void Update();
 	void Render();
 
+	void SpawnEnemyNormal();
+
 private:
 	LevelData* myLevelData = nullptr;
+	Slush::EntityManager myEntityManager;
 
 	int myCurrentWaveIndex = 0;
 	Slush::Timer myNextWaveTimer;

--- a/Solution/TopDownGame/LevelEditorDockable.cpp
+++ b/Solution/TopDownGame/LevelEditorDockable.cpp
@@ -224,6 +224,21 @@ void LevelEditorDockable::OnBuildUI()
 	}
 
 	ImGui::Text("Level Editor");
+	ImGui::Separator();
+
+	if (ImGui::Button("Spawn Normal"))
+		myLevel.SpawnEnemyNormal();
+
+	if (ImGui::Button("Spawn Fast"))
+		myLevel.SpawnEnemyFast();
+
+	if (ImGui::Button("Spawn Slow"))
+		myLevel.SpawnEnemySlow();
+
+	if (ImGui::Button("Damage All Enemies"))
+		myLevel.DamageAllEnemies();
+
+	ImGui::Separator();
 
 	if (myIsBoxCutModeActive)
 	{

--- a/Solution/TopDownGame/Navmesh.cpp
+++ b/Solution/TopDownGame/Navmesh.cpp
@@ -424,7 +424,7 @@ bool Navmesh::StringPull(const Vector2f& aStart, const Vector2f& aGoal, const Pa
 	return true;
 }
 
-bool Navmesh::FindPath(const Vector2f& aStart, const Vector2f& aGoal, FW_GrowingArray<Vector2f>& outWaypoints, PathCorridor& outCorridor) const
+bool Navmesh::FindPath(const Vector2f& aStart, const Vector2f& aGoal, FW_GrowingArray<Vector2f>& outWaypoints, PathCorridor* outCorridor) const
 {
 	Triangle* startTriangle = FindTriangleContaining(aStart);
 	Triangle* goalTriangle = FindTriangleContaining(aGoal);
@@ -439,10 +439,11 @@ bool Navmesh::FindPath(const Vector2f& aStart, const Vector2f& aGoal, FW_Growing
 	}
 
 	// Build into a local corridor and only hand it to the caller once the search has
-	// actually succeeded, so a reused outCorridor is replaced rather than appended to
+	// actually succeeded, so a reused *outCorridor is replaced rather than appended to
 	// (guaranteeing the zero-portal same-triangle case) and stays untouched on failure.
-	outCorridor = foundCorridor;
-	return StringPull(aStart, aGoal, outCorridor, outWaypoints);
+	if (outCorridor != nullptr)
+		*outCorridor = foundCorridor;
+	return StringPull(aStart, aGoal, foundCorridor, outWaypoints);
 }
 
 Navmesh::Vertex* Navmesh::GetVertex(int x, int y) const

--- a/Solution/TopDownGame/Navmesh.h
+++ b/Solution/TopDownGame/Navmesh.h
@@ -29,7 +29,7 @@ public:
 
 	bool BuildEdgeCenterPath(const Vector2f& aStart, const Vector2f& aGoal, const PathCorridor& aCorridor, FW_GrowingArray<Vector2f>& outWaypoints) const;
 	bool StringPull(const Vector2f& aStart, const Vector2f& aGoal, const PathCorridor& aCorridor, FW_GrowingArray<Vector2f>& outWaypoints) const;
-	bool FindPath(const Vector2f& aStart, const Vector2f& aGoal, FW_GrowingArray<Vector2f>& outWaypoints, PathCorridor& outCorridor) const;
+	bool FindPath(const Vector2f& aStart, const Vector2f& aGoal, FW_GrowingArray<Vector2f>& outWaypoints, PathCorridor* outCorridor = nullptr) const;
 
 	void CutHole(const FW_GrowingArray<Vector2f>& aPolygon);
 

--- a/Solution/TopDownGame/NavmeshDebuggerDockable.cpp
+++ b/Solution/TopDownGame/NavmeshDebuggerDockable.cpp
@@ -150,8 +150,7 @@ void NavmeshDebuggerDockable::UpdatePathfindTestMode()
 	myPathfindTestHasStart = false;
 
 	FW_GrowingArray<Vector2f> waypoints;
-	Navmesh::PathCorridor corridor;
-	if (!myNavmesh.FindPath(myPathfindTestStart, goal, waypoints, corridor))
+	if (!myNavmesh.FindPath(myPathfindTestStart, goal, waypoints))
 		return;
 
 	PathfindResult& result = myPathfindResults.Add();

--- a/Solution/TopDownGame/NavmeshTestSuite.cpp
+++ b/Solution/TopDownGame/NavmeshTestSuite.cpp
@@ -25,7 +25,7 @@ namespace NavmeshTestSuite
 
 		FW_GrowingArray<Vector2f> waypoints;
 		Navmesh::PathCorridor corridor;
-		bool found = mesh.FindPath(start, goal, waypoints, corridor);
+		bool found = mesh.FindPath(start, goal, waypoints, &corridor);
 
 		FW_ASSERT(found, "Expected FindPath to succeed between two reachable points");
 		FW_ASSERT(waypoints.Count() >= 2, "Expected at least a start and goal waypoint");
@@ -43,7 +43,7 @@ namespace NavmeshTestSuite
 
 		FW_GrowingArray<Vector2f> waypoints;
 		Navmesh::PathCorridor corridor;
-		bool found = mesh.FindPath(start, goal, waypoints, corridor);
+		bool found = mesh.FindPath(start, goal, waypoints, &corridor);
 
 		FW_ASSERT(!found, "Expected FindPath to fail when the start position is outside the mesh");
 		FW_ASSERT(waypoints.IsEmpty(), "Expected no waypoints for a failed path");
@@ -67,7 +67,7 @@ namespace NavmeshTestSuite
 
 		FW_GrowingArray<Vector2f> waypoints;
 		Navmesh::PathCorridor corridor;
-		bool found = mesh.FindPath(start, goal, waypoints, corridor);
+		bool found = mesh.FindPath(start, goal, waypoints, &corridor);
 
 		FW_ASSERT(!found, "Expected FindPath to fail once a full-width cut disconnects start from goal");
 	}
@@ -82,7 +82,7 @@ namespace NavmeshTestSuite
 
 		FW_GrowingArray<Vector2f> waypoints;
 		Navmesh::PathCorridor corridor;
-		bool found = mesh.FindPath(start, goal, waypoints, corridor);
+		bool found = mesh.FindPath(start, goal, waypoints, &corridor);
 
 		FW_ASSERT(found, "Expected FindPath to succeed for a same-triangle start/goal");
 		FW_ASSERT(corridor.myPortals.IsEmpty(), "Expected a zero-portal corridor for a same-triangle path");
@@ -110,7 +110,7 @@ namespace NavmeshTestSuite
 
 		FW_GrowingArray<Vector2f> stringPulledWaypoints;
 		Navmesh::PathCorridor corridor;
-		bool found = mesh.FindPath(start, goal, stringPulledWaypoints, corridor);
+		bool found = mesh.FindPath(start, goal, stringPulledWaypoints, &corridor);
 
 		FW_ASSERT(found, "Expected FindPath to succeed by routing around the cut");
 		FW_ASSERT(corridor.myPortals.Count() > 1, "Expected a multi-portal corridor bending around the cut");
@@ -139,7 +139,7 @@ namespace NavmeshTestSuite
 
 		FW_GrowingArray<Vector2f> waypoints;
 		Navmesh::PathCorridor corridor;
-		bool found = mesh.FindPath(start, goal, waypoints, corridor);
+		bool found = mesh.FindPath(start, goal, waypoints, &corridor);
 		FW_ASSERT(found, "Expected the initial FindPath to succeed");
 
 		// Simulate an entity that has moved partway along its route: re-funnel the same,
@@ -292,11 +292,11 @@ namespace NavmeshTestSuite
 
 		FW_GrowingArray<Vector2f> originalWaypoints;
 		Navmesh::PathCorridor originalCorridor;
-		bool originalFound = original.myNavmesh.FindPath(start, goal, originalWaypoints, originalCorridor);
+		bool originalFound = original.myNavmesh.FindPath(start, goal, originalWaypoints, &originalCorridor);
 
 		FW_GrowingArray<Vector2f> loadedWaypoints;
 		Navmesh::PathCorridor loadedCorridor;
-		bool loadedFound = loaded.myNavmesh.FindPath(start, goal, loadedWaypoints, loadedCorridor);
+		bool loadedFound = loaded.myNavmesh.FindPath(start, goal, loadedWaypoints, &loadedCorridor);
 
 		FW_ASSERT(originalFound && loadedFound, "Expected FindPath to succeed on both the original and the round-tripped navmesh");
 		FW_ASSERT(loadedWaypoints.Count() == originalWaypoints.Count(), "Expected matching waypoint counts after a save/load round-trip");

--- a/Solution/TopDownGame/TopDownGame.vcxproj
+++ b/Solution/TopDownGame/TopDownGame.vcxproj
@@ -151,6 +151,9 @@
     <ClCompile Include="Level\NavmeshData.cpp" />
     <ClCompile Include="Level\LevelData.cpp" />
     <ClCompile Include="Level\Level.cpp" />
+	<ClCompile Include="TopDownGameGlobals.cpp" />
+	<ClCompile Include="EntitySystem\EntityManager.cpp" />
+	<ClCompile Include="Components\MovementComponent.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
@@ -167,6 +170,8 @@
     <ClInclude Include="Level\NavmeshData.h" />
     <ClInclude Include="Level\LevelData.h" />
     <ClInclude Include="Level\Level.h" />
+	<ClInclude Include="TopDownGameGlobals.h" />
+	<ClInclude Include="Components\MovementComponent.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Solution/TopDownGame/TopDownGame.vcxproj
+++ b/Solution/TopDownGame/TopDownGame.vcxproj
@@ -154,6 +154,7 @@
 	<ClCompile Include="TopDownGameGlobals.cpp" />
 	<ClCompile Include="EntitySystem\EntityManager.cpp" />
 	<ClCompile Include="Components\MovementComponent.cpp" />
+	<ClCompile Include="Components\HealthComponent.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
@@ -172,6 +173,7 @@
     <ClInclude Include="Level\Level.h" />
 	<ClInclude Include="TopDownGameGlobals.h" />
 	<ClInclude Include="Components\MovementComponent.h" />
+	<ClInclude Include="Components\HealthComponent.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Solution/TopDownGame/TopDownGame.vcxproj
+++ b/Solution/TopDownGame/TopDownGame.vcxproj
@@ -73,12 +73,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(RepoRoot)Workbed\$(ProjectName)\</OutDir>
     <IntDir>$(RepoRoot)Build_Output\$(ProjectName)\$(Configuration)\</IntDir>
-    <IncludePath>$(SolutionDir)\Engine;$(SolutionDir)..\SFML\include;$(SolutionDir)\Framework;$(SolutionDir)\ActionGame;$(SolutionDir)\TopDownGame;$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)\Engine;$(SolutionDir)..\SFML\include;$(SolutionDir)\Framework;$(SolutionDir)\TopDownGame;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(RepoRoot)Workbed\$(ProjectName)\</OutDir>
     <IntDir>$(RepoRoot)Build_Output\$(ProjectName)\$(Configuration)\</IntDir>
-    <IncludePath>$(SolutionDir)\Engine;$(SolutionDir)..\SFML\include;$(SolutionDir)\Framework;$(SolutionDir)\ActionGame;$(SolutionDir)\TopDownGame;$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)\Engine;$(SolutionDir)..\SFML\include;$(SolutionDir)\Framework;$(SolutionDir)\TopDownGame;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Solution/TopDownGame/TopDownGame.vcxproj.filters
+++ b/Solution/TopDownGame/TopDownGame.vcxproj.filters
@@ -12,6 +12,9 @@
     <ClCompile Include="Level\NavmeshData.cpp" />
     <ClCompile Include="Level\LevelData.cpp" />
     <ClCompile Include="Level\Level.cpp" />
+	<ClCompile Include="TopDownGameGlobals.cpp" />
+	<ClCompile Include="EntitySystem\EntityManager.cpp" />
+	<ClCompile Include="Components\MovementComponent.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -24,5 +27,7 @@
     <ClInclude Include="Level\NavmeshData.h" />
     <ClInclude Include="Level\LevelData.h" />
     <ClInclude Include="Level\Level.h" />
+	<ClInclude Include="TopDownGameGlobals.h" />
+	<ClInclude Include="Components\MovementComponent.h" />
   </ItemGroup>
 </Project>

--- a/Solution/TopDownGame/TopDownGame.vcxproj.filters
+++ b/Solution/TopDownGame/TopDownGame.vcxproj.filters
@@ -15,6 +15,7 @@
 	<ClCompile Include="TopDownGameGlobals.cpp" />
 	<ClCompile Include="EntitySystem\EntityManager.cpp" />
 	<ClCompile Include="Components\MovementComponent.cpp" />
+	<ClCompile Include="Components\HealthComponent.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -29,5 +30,6 @@
     <ClInclude Include="Level\Level.h" />
 	<ClInclude Include="TopDownGameGlobals.h" />
 	<ClInclude Include="Components\MovementComponent.h" />
+	<ClInclude Include="Components\HealthComponent.h" />
   </ItemGroup>
 </Project>

--- a/Solution/TopDownGame/TopDownGameGlobals.cpp
+++ b/Solution/TopDownGame/TopDownGameGlobals.cpp
@@ -1,0 +1,28 @@
+#include "stdafx.h"
+
+#include "TopDownGameGlobals.h"
+
+#include "Level/Level.h"
+
+TopDownGameGlobals* TopDownGameGlobals::ourInstance = nullptr;
+
+TopDownGameGlobals& TopDownGameGlobals::GetInstance()
+{
+	if (!ourInstance)
+	{
+		ourInstance = new TopDownGameGlobals();
+	}
+
+	return *ourInstance;
+}
+
+void TopDownGameGlobals::Destroy()
+{
+	FW_SAFE_DELETE(ourInstance);
+}
+
+Level& TopDownGameGlobals::GetLevel()
+{
+	FW_ASSERT(myLevel != nullptr, "Need to set a Level");
+	return *myLevel;
+}

--- a/Solution/TopDownGame/TopDownGameGlobals.h
+++ b/Solution/TopDownGame/TopDownGameGlobals.h
@@ -1,0 +1,21 @@
+#pragma once
+
+class Level;
+
+class TopDownGameGlobals
+{
+public:
+	static TopDownGameGlobals& GetInstance();
+	static void Destroy();
+
+	void SetLevel(Level* aLevel) { myLevel = aLevel; }
+	Level& GetLevel();
+
+private:
+	TopDownGameGlobals() = default;
+	~TopDownGameGlobals() = default;
+
+	static TopDownGameGlobals* ourInstance;
+
+	Level* myLevel = nullptr;
+};

--- a/Solution/TopDownGame/main.cpp
+++ b/Solution/TopDownGame/main.cpp
@@ -7,6 +7,9 @@
 #include "Graphics/Window.h"
 #include "Core/Input.h"
 
+#include "EntitySystem/EntityManager.h"
+#include "EntitySystem/EntityPrefab.h"
+
 #include "Level/Level.h"
 #include "Level/LevelData.h"
 #include "Level/NavmeshData.h"
@@ -14,15 +17,19 @@
 #include "NavmeshTestSuite.h"
 #include "NavmeshDebuggingLayout.h"
 #include "LevelEditorLayout.h"
+#include "TopDownGameGlobals.h"
 
 class App : public Slush::IApp
 {
 public:
 	void Initialize() override
 	{
+		Slush::EntityManager::RegisterComponents();
+
 		Slush::AssetRegistry& assets = Slush::AssetRegistry::GetInstance();
 		assets.RegisterAssetType<NavmeshData>();
 		assets.RegisterAssetType<LevelData>();
+		assets.RegisterAssetType<Slush::EntityPrefab>();
 		assets.LoadAllAssets();
 
 		myLevel = new Level();
@@ -35,6 +42,7 @@ public:
 	void Shutdown() override
 	{
 		FW_SAFE_DELETE(myLevel);
+		TopDownGameGlobals::Destroy();
 	}
 
 	void Update() override

--- a/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Fast.prefab
+++ b/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Fast.prefab
@@ -1,0 +1,24 @@
+Entity Prefab
+{
+	version 1
+	sprite
+	{
+		version 1
+		color -256
+		size
+		{
+			width 32.000
+			height 32.000
+		}
+	}
+	movement
+	{
+		version 1
+		movespeed 200.000
+	}
+	health
+	{
+		version 1
+		maxhealth 20
+	}
+}

--- a/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Normal.prefab
+++ b/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Normal.prefab
@@ -16,4 +16,9 @@ Entity Prefab
 		version 1
 		movespeed 100.000
 	}
+	health
+	{
+		version 1
+		maxhealth 30
+	}
 }

--- a/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Normal.prefab
+++ b/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Normal.prefab
@@ -1,0 +1,19 @@
+Entity Prefab
+{
+	version 1
+	sprite
+	{
+		version 1
+		color -16711936
+		size
+		{
+			width 32.000
+			height 32.000
+		}
+	}
+	movement
+	{
+		version 1
+		movespeed 100.000
+	}
+}

--- a/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Slow.prefab
+++ b/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Slow.prefab
@@ -1,0 +1,24 @@
+Entity Prefab
+{
+	version 1
+	sprite
+	{
+		version 1
+		color -65536
+		size
+		{
+			width 32.000
+			height 32.000
+		}
+	}
+	movement
+	{
+		version 1
+		movespeed 50.000
+	}
+	health
+	{
+		version 1
+		maxhealth 50
+	}
+}


### PR DESCRIPTION
## Description
Add TopDownGame ground enemies with movement, health, variants, debug keys, and Level Editor controls.

Closes #51

## Agent End-of-run Summary
Completed all four phases in focused commits: enemy movement and normal spawning (`3101c50`), health and damage (`d43bfcc`), fast and slow variants (`2a65589`), and Level Editor controls (`0b04f11`).

Phase 1 initially exposed a SpriteComponent assertion for plain color rectangles. The component now accepts its existing color-only rectangle fallback, after which the key-7 headless run and interactive test passed. Phase 2 and Phase 3 built successfully and passed headless debug-key sequences. Phase 4 built successfully and its four Level Editor actions were manually verified.

Final review found no concrete correctness or regression risks. Review the committed changes on `issue-51` before deciding whether the issue is complete or needs more work.

## Agent Verifications
Phase 1: `MSBuild Solution\Solution.sln /p:Configuration=Debug /p:Platform=x86 /m /nodeReuse:false` passed. Headless TopDownGame with injected key `7` stayed alive; interactive key-7 spawning passed.

Phase 2: the same solution build passed. Headless TopDownGame spawned an enemy and processed three injected key-8 damage events without crashing.

Phase 3: the same solution build passed. Headless TopDownGame spawned Normal, Fast, and Slow via injected keys `7`, `9`, and `0` without crashing.

Phase 4: the same solution build passed. Interactive Level Editor verification passed for Spawn Normal, Spawn Fast, Spawn Slow, and Damage All Enemies.