### PR TITLE
Tower combat framework (targeting, range, damage, attack speed)

### DIFF
--- a/Solution/TopDownGame/Components/MovementComponent.cpp
+++ b/Solution/TopDownGame/Components/MovementComponent.cpp
@@ -63,3 +63,17 @@ void MovementComponent::Update()
 		myEntity.myIsMarkedForRemoval = true;
 	}
 }
+
+float MovementComponent::GetRemainingPathDistance() const
+{
+	if (myNextWaypointIndex >= myWaypoints.Count())
+		return 0.f;
+
+	float remainingDistance = Length(myWaypoints[myNextWaypointIndex] - myEntity.myPosition);
+	for (int waypointIndex = myNextWaypointIndex + 1; waypointIndex < myWaypoints.Count(); ++waypointIndex)
+	{
+		remainingDistance += Length(myWaypoints[waypointIndex] - myWaypoints[waypointIndex - 1]);
+	}
+
+	return remainingDistance;
+}

--- a/Solution/TopDownGame/Components/MovementComponent.h
+++ b/Solution/TopDownGame/Components/MovementComponent.h
@@ -20,6 +20,7 @@ public:
 
 	void OnEnterWorld() override;
 	void Update() override;
+	float GetRemainingPathDistance() const;
 
 private:
 	float myMoveSpeed = 0.f;

--- a/Solution/TopDownGame/Components/TargetableComponent.cpp
+++ b/Solution/TopDownGame/Components/TargetableComponent.cpp
@@ -1,0 +1,8 @@
+#include "stdafx.h"
+
+#include "TargetableComponent.h"
+
+TargetableComponent::TargetableComponent(Slush::Entity& anEntity, const Slush::EntityPrefab& anEntityPrefab)
+	: Slush::Component(anEntity, anEntityPrefab)
+{
+}

--- a/Solution/TopDownGame/Components/TargetableComponent.h
+++ b/Solution/TopDownGame/Components/TargetableComponent.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <EntitySystem/Component.h>
+
+class TargetableComponent : public Slush::Component
+{
+public:
+	COMPONENT_HELPER("Targetable", "targetable", 1);
+
+	TargetableComponent(Slush::Entity& anEntity, const Slush::EntityPrefab& anEntityPrefab);
+};

--- a/Solution/TopDownGame/Components/TowerCombatComponent.cpp
+++ b/Solution/TopDownGame/Components/TowerCombatComponent.cpp
@@ -2,7 +2,6 @@
 
 #include "TowerCombatComponent.h"
 
-#include <float.h>
 #include <EntitySystem/Entity.h>
 #include <EntitySystem/EntityManager.h>
 #include <imgui/ImGuiWidgets.h>
@@ -65,7 +64,8 @@ void TowerCombatComponent::AcquireTarget()
 	FW_GrowingArray<Slush::EntityHandle> entities;
 	myEntity.myEntityManager.GetAllEntities(entities);
 
-	float bestRemainingPathDistance = FLT_MAX;
+	float bestRemainingPathDistance = 0.f;
+	bool hasTarget = false;
 	for (const Slush::EntityHandle& handle : entities)
 	{
 		Slush::Entity* entity = handle.Get();
@@ -74,10 +74,11 @@ void TowerCombatComponent::AcquireTarget()
 
 		MovementComponent* movement = entity->GetComponent<MovementComponent>();
 		const float remainingPathDistance = movement ? movement->GetRemainingPathDistance() : 0.f;
-		if (remainingPathDistance < bestRemainingPathDistance)
+		if (!hasTarget || remainingPathDistance < bestRemainingPathDistance)
 		{
 			myTarget = handle;
 			bestRemainingPathDistance = remainingPathDistance;
+			hasTarget = true;
 		}
 	}
 }

--- a/Solution/TopDownGame/Components/TowerCombatComponent.cpp
+++ b/Solution/TopDownGame/Components/TowerCombatComponent.cpp
@@ -1,0 +1,101 @@
+#include "stdafx.h"
+
+#include "TowerCombatComponent.h"
+
+#include <float.h>
+#include <EntitySystem/Entity.h>
+#include <EntitySystem/EntityManager.h>
+#include <imgui/ImGuiWidgets.h>
+
+#include "HealthComponent.h"
+#include "MovementComponent.h"
+#include "TargetableComponent.h"
+
+void TowerCombatComponent::Data::OnParse(Slush::AssetParser::Handle aComponentHandle, unsigned int /*aVersion*/)
+{
+	aComponentHandle.ParseFloatField("range", myRange);
+	aComponentHandle.ParseFloatField("cooldown", myCooldown);
+	aComponentHandle.ParseIntField("damage", myDamage);
+}
+
+void TowerCombatComponent::Data::OnBuildUI()
+{
+	Slush::ImGuiWidgets::InputFloat("Range", &myRange);
+	Slush::ImGuiWidgets::InputFloat("Cooldown", &myCooldown);
+	Slush::ImGuiWidgets::InputInt("Damage", &myDamage);
+}
+
+TowerCombatComponent::TowerCombatComponent(Slush::Entity& anEntity, const Slush::EntityPrefab& anEntityPrefab)
+	: Slush::Component(anEntity, anEntityPrefab)
+{
+	const Data& data = anEntityPrefab.GetComponentData<TowerCombatComponent>();
+	myRange = data.myRange;
+	myCooldown = data.myCooldown;
+	myDamage = data.myDamage;
+
+	SLUSH_DEBUG("Tower '%s' created at (%.1f, %.1f) with damage %d", myEntityPrefab.GetAssetName().GetBuffer(), myEntity.myPosition.x, myEntity.myPosition.y, myDamage);
+}
+
+void TowerCombatComponent::Update()
+{
+	Slush::Entity* target = myTarget.Get();
+	if (!target || target->myIsMarkedForRemoval || !IsTargetInRange(*target))
+	{
+		myTarget.Clear();
+		AcquireTarget();
+	}
+
+	if (!myTarget.IsValid())
+		return;
+
+	if (!myAttackTimer.IsStarted() || myAttackTimer.HasExpired())
+	{
+		AttackTarget();
+		myAttackTimer.Start(myCooldown);
+	}
+}
+
+bool TowerCombatComponent::IsTargetInRange(const Slush::Entity& anEntity) const
+{
+	return Length2(anEntity.myPosition - myEntity.myPosition) <= FW_Square(myRange);
+}
+
+void TowerCombatComponent::AcquireTarget()
+{
+	FW_GrowingArray<Slush::EntityHandle> entities;
+	myEntity.myEntityManager.GetAllEntities(entities);
+
+	float bestRemainingPathDistance = FLT_MAX;
+	for (const Slush::EntityHandle& handle : entities)
+	{
+		Slush::Entity* entity = handle.Get();
+		if (!entity || entity->myIsMarkedForRemoval || !entity->GetComponent<TargetableComponent>() || !IsTargetInRange(*entity))
+			continue;
+
+		MovementComponent* movement = entity->GetComponent<MovementComponent>();
+		FW_ASSERT(movement, "Tower target is missing a MovementComponent");
+
+		const float remainingPathDistance = movement->GetRemainingPathDistance();
+		if (remainingPathDistance < bestRemainingPathDistance)
+		{
+			myTarget = handle;
+			bestRemainingPathDistance = remainingPathDistance;
+		}
+	}
+}
+
+void TowerCombatComponent::AttackTarget()
+{
+	Slush::Entity* target = myTarget.Get();
+	if (!target)
+		return;
+
+	HealthComponent* health = target->GetComponent<HealthComponent>();
+	FW_ASSERT(health, "Tower target is missing a HealthComponent");
+
+	health->DealDamage(myDamage);
+	if (health->IsDead())
+	{
+		SLUSH_DEBUG("Tower '%s' at (%.1f, %.1f) killed a target at (%.1f, %.1f) with damage %d", myEntityPrefab.GetAssetName().GetBuffer(), myEntity.myPosition.x, myEntity.myPosition.y, target->myPosition.x, target->myPosition.y, myDamage);
+	}
+}

--- a/Solution/TopDownGame/Components/TowerCombatComponent.cpp
+++ b/Solution/TopDownGame/Components/TowerCombatComponent.cpp
@@ -73,9 +73,7 @@ void TowerCombatComponent::AcquireTarget()
 			continue;
 
 		MovementComponent* movement = entity->GetComponent<MovementComponent>();
-		FW_ASSERT(movement, "Tower target is missing a MovementComponent");
-
-		const float remainingPathDistance = movement->GetRemainingPathDistance();
+		const float remainingPathDistance = movement ? movement->GetRemainingPathDistance() : 0.f;
 		if (remainingPathDistance < bestRemainingPathDistance)
 		{
 			myTarget = handle;

--- a/Solution/TopDownGame/Components/TowerCombatComponent.h
+++ b/Solution/TopDownGame/Components/TowerCombatComponent.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <EntitySystem/Component.h>
+#include <EntitySystem/EntityHandle.h>
+#include <Core/Time.h>
+
+class TowerCombatComponent : public Slush::Component
+{
+public:
+	COMPONENT_HELPER("Tower Combat", "towercombat", 1);
+
+	struct Data : public Slush::Component::BaseData
+	{
+		void OnParse(Slush::AssetParser::Handle aComponentHandle, unsigned int aVersion) override;
+		void OnBuildUI() override;
+
+		float myRange = 300.f;
+		float myCooldown = 1.f;
+		int myDamage = 10;
+	};
+
+	TowerCombatComponent(Slush::Entity& anEntity, const Slush::EntityPrefab& anEntityPrefab);
+
+	void Update() override;
+
+private:
+	bool IsTargetInRange(const Slush::Entity& anEntity) const;
+	void AcquireTarget();
+	void AttackTarget();
+
+	float myRange = 0.f;
+	float myCooldown = 0.f;
+	int myDamage = 0;
+	Slush::EntityHandle myTarget;
+	Slush::Timer myAttackTimer;
+};

--- a/Solution/TopDownGame/EntitySystem/EntityManager.cpp
+++ b/Solution/TopDownGame/EntitySystem/EntityManager.cpp
@@ -6,6 +6,7 @@
 
 #include "Components/MovementComponent.h"
 #include "Components/HealthComponent.h"
+#include "Components/TargetableComponent.h"
 
 void Slush::EntityManager::RegisterComponents()
 {
@@ -13,4 +14,5 @@ void Slush::EntityManager::RegisterComponents()
 	registry.RegisterComponent<Slush::SpriteComponent, Slush::SpriteComponent::Data>();
 	registry.RegisterComponent<MovementComponent, MovementComponent::Data>();
 	registry.RegisterComponent<HealthComponent, HealthComponent::Data>();
+	registry.RegisterComponent<TargetableComponent>();
 }

--- a/Solution/TopDownGame/EntitySystem/EntityManager.cpp
+++ b/Solution/TopDownGame/EntitySystem/EntityManager.cpp
@@ -7,6 +7,7 @@
 #include "Components/MovementComponent.h"
 #include "Components/HealthComponent.h"
 #include "Components/TargetableComponent.h"
+#include "Components/TowerCombatComponent.h"
 
 void Slush::EntityManager::RegisterComponents()
 {
@@ -15,4 +16,5 @@ void Slush::EntityManager::RegisterComponents()
 	registry.RegisterComponent<MovementComponent, MovementComponent::Data>();
 	registry.RegisterComponent<HealthComponent, HealthComponent::Data>();
 	registry.RegisterComponent<TargetableComponent>();
+	registry.RegisterComponent<TowerCombatComponent, TowerCombatComponent::Data>();
 }

--- a/Solution/TopDownGame/Level/Level.cpp
+++ b/Solution/TopDownGame/Level/Level.cpp
@@ -51,6 +51,14 @@ void Level::Update()
 	{
 		SpawnEnemySlow();
 	}
+	if (engine.GetInput().WasKeyReleased(Slush::Input::_5))
+	{
+		SpawnTowerBasic();
+	}
+	if (engine.GetInput().WasKeyReleased(Slush::Input::_6))
+	{
+		SpawnTowerZeroDamage();
+	}
 
 	GetNavmesh().Update();
 	myEntityManager.Update();
@@ -76,6 +84,16 @@ void Level::SpawnEnemyFast()
 void Level::SpawnEnemySlow()
 {
 	SpawnEnemy("Enemy_Slow");
+}
+
+void Level::SpawnTowerBasic()
+{
+	SpawnEnemy("Tower_Basic");
+}
+
+void Level::SpawnTowerZeroDamage()
+{
+	SpawnEnemy("Tower_ZeroDamage");
 }
 
 void Level::SpawnEnemy(const char* aPrefabName)

--- a/Solution/TopDownGame/Level/Level.h
+++ b/Solution/TopDownGame/Level/Level.h
@@ -21,6 +21,8 @@ public:
 	void SpawnEnemyNormal();
 	void SpawnEnemyFast();
 	void SpawnEnemySlow();
+	void SpawnTowerBasic();
+	void SpawnTowerZeroDamage();
 	void DamageAllEnemies();
 
 private:

--- a/Solution/TopDownGame/NavmeshTestSuite.cpp
+++ b/Solution/TopDownGame/NavmeshTestSuite.cpp
@@ -4,6 +4,8 @@
 #include "Navmesh.h"
 #include "Level/NavmeshData.h"
 
+#include <windows.h>
+
 namespace NavmeshTestSuite
 {
 	float GetTotalPathLength(const FW_GrowingArray<Vector2f>& aWaypoints)
@@ -269,18 +271,24 @@ namespace NavmeshTestSuite
 		// of the real data/navmeshes/ folder - that folder is scanned by AssetStorage<NavmeshData>
 		// on every launch, so writing there would leave this fixture behind as a permanent, visible
 		// asset in the editor UI, not just a test artifact.
-		// "temp/" already exists (FW_UnitTestSuite's own file-processor test lives there) -
-		// CreateFolderIfNecessary() can't be used here anyway, since it assumes every path
-		// contains a "data" segment.
-		const char* testFilePath = "temp/navmesh_roundtrip_test.navmesh";
+		// Resolve from the executable rather than the current working directory. These tests run
+		// before Engine::Initialize() sets FW_FileSystem's data folder, so a relative path would
+		// otherwise write into whichever folder launched the game.
+		char modulePath[MAX_PATH];
+		GetModuleFileNameA(nullptr, modulePath, MAX_PATH);
+		FW_String testFilePath = modulePath;
+		const int lastFolderSeparator = testFilePath.RFind("\\");
+		FW_ASSERT(lastFolderSeparator != -1, "Expected executable path to include a folder");
+		testFilePath = testFilePath.SubStr(0, lastFolderSeparator);
+		testFilePath += "/temp/navmesh_roundtrip_test.navmesh";
 
 		Slush::AssetParser writer;
 		Slush::AssetParser::Handle writeHandle = writer.StartWriting("NavmeshData");
 		original.OnParse(writeHandle, 1);
-		writer.FinishWriting(testFilePath);
+		writer.FinishWriting(testFilePath.GetBuffer());
 
 		Slush::AssetParser reader;
-		Slush::AssetParser::Handle readHandle = reader.Load(testFilePath);
+		Slush::AssetParser::Handle readHandle = reader.Load(testFilePath.GetBuffer());
 		NavmeshData loaded("navmesh_roundtrip_test", 0);
 		loaded.OnParse(readHandle, 1);
 

--- a/Solution/TopDownGame/TopDownGame.vcxproj
+++ b/Solution/TopDownGame/TopDownGame.vcxproj
@@ -156,6 +156,7 @@
 	<ClCompile Include="Components\MovementComponent.cpp" />
 	<ClCompile Include="Components\HealthComponent.cpp" />
 	<ClCompile Include="Components\TargetableComponent.cpp" />
+	<ClCompile Include="Components\TowerCombatComponent.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
@@ -176,6 +177,7 @@
 	<ClInclude Include="Components\MovementComponent.h" />
 	<ClInclude Include="Components\HealthComponent.h" />
 	<ClInclude Include="Components\TargetableComponent.h" />
+	<ClInclude Include="Components\TowerCombatComponent.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Solution/TopDownGame/TopDownGame.vcxproj
+++ b/Solution/TopDownGame/TopDownGame.vcxproj
@@ -155,6 +155,7 @@
 	<ClCompile Include="EntitySystem\EntityManager.cpp" />
 	<ClCompile Include="Components\MovementComponent.cpp" />
 	<ClCompile Include="Components\HealthComponent.cpp" />
+	<ClCompile Include="Components\TargetableComponent.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
@@ -174,6 +175,7 @@
 	<ClInclude Include="TopDownGameGlobals.h" />
 	<ClInclude Include="Components\MovementComponent.h" />
 	<ClInclude Include="Components\HealthComponent.h" />
+	<ClInclude Include="Components\TargetableComponent.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Solution/TopDownGame/TopDownGame.vcxproj.filters
+++ b/Solution/TopDownGame/TopDownGame.vcxproj.filters
@@ -17,6 +17,7 @@
 	<ClCompile Include="Components\MovementComponent.cpp" />
 	<ClCompile Include="Components\HealthComponent.cpp" />
 	<ClCompile Include="Components\TargetableComponent.cpp" />
+	<ClCompile Include="Components\TowerCombatComponent.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -33,5 +34,6 @@
 	<ClInclude Include="Components\MovementComponent.h" />
 	<ClInclude Include="Components\HealthComponent.h" />
 	<ClInclude Include="Components\TargetableComponent.h" />
+	<ClInclude Include="Components\TowerCombatComponent.h" />
   </ItemGroup>
 </Project>

--- a/Solution/TopDownGame/TopDownGame.vcxproj.filters
+++ b/Solution/TopDownGame/TopDownGame.vcxproj.filters
@@ -16,6 +16,7 @@
 	<ClCompile Include="EntitySystem\EntityManager.cpp" />
 	<ClCompile Include="Components\MovementComponent.cpp" />
 	<ClCompile Include="Components\HealthComponent.cpp" />
+	<ClCompile Include="Components\TargetableComponent.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -31,5 +32,6 @@
 	<ClInclude Include="TopDownGameGlobals.h" />
 	<ClInclude Include="Components\MovementComponent.h" />
 	<ClInclude Include="Components\HealthComponent.h" />
+	<ClInclude Include="Components\TargetableComponent.h" />
   </ItemGroup>
 </Project>

--- a/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Fast.prefab
+++ b/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Fast.prefab
@@ -21,4 +21,8 @@ Entity Prefab
 		version 1
 		maxhealth 20
 	}
+	targetable
+	{
+		version 1
+	}
 }

--- a/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Normal.prefab
+++ b/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Normal.prefab
@@ -21,4 +21,8 @@ Entity Prefab
 		version 1
 		maxhealth 30
 	}
+	targetable
+	{
+		version 1
+	}
 }

--- a/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Slow.prefab
+++ b/Workbed/TopDownGame/Data/EntityPrefabs/Enemy_Slow.prefab
@@ -21,4 +21,8 @@ Entity Prefab
 		version 1
 		maxhealth 50
 	}
+	targetable
+	{
+		version 1
+	}
 }

--- a/Workbed/TopDownGame/Data/EntityPrefabs/Tower_Basic.prefab
+++ b/Workbed/TopDownGame/Data/EntityPrefabs/Tower_Basic.prefab
@@ -1,0 +1,21 @@
+Entity Prefab
+{
+	version 1
+	sprite
+	{
+		version 1
+		color -16776961
+		size
+		{
+			width 48.000
+			height 48.000
+		}
+	}
+	towercombat
+	{
+		version 1
+		range 300.000
+		cooldown 1.000
+		damage 10
+	}
+}

--- a/Workbed/TopDownGame/Data/EntityPrefabs/Tower_ZeroDamage.prefab
+++ b/Workbed/TopDownGame/Data/EntityPrefabs/Tower_ZeroDamage.prefab
@@ -1,0 +1,21 @@
+Entity Prefab
+{
+	version 1
+	sprite
+	{
+		version 1
+		color -65281
+		size
+		{
+			width 48.000
+			height 48.000
+		}
+	}
+	towercombat
+	{
+		version 1
+		range 300.000
+		cooldown 1.000
+		damage 0
+	}
+}


### PR DESCRIPTION
## Description

Implement prefab-configured, single-target tower combat for TopDownGame.

Closes #47

## Agent End-of-run Summary

Completed phases 1–3: target eligibility and remaining-path-distance queries; reusable prefab-driven tower combat; and proof-tower prefabs with debug spawning and end-to-end coverage. A follow-up commit also handles stationary targetable entities safely.

The full `Debug|x86` solution build passed with 0 warnings and 0 errors. Existing headless verification artifacts show the basic tower’s sparse creation/death logging. The automatic review found no actionable correctness findings.

Review the committed changes on `issue-47` before deciding whether the issue is fully finished or needs more work.

## Agent Verifications

Phase 1: Full `Debug|x86` solution build and headless TopDownGame verification confirmed all enemy types still spawn and move with the new targetability and path-progress infrastructure.

Phase 2: Solution build and headless runs verified target-handle safety, inclusive range behavior, immediate first damage, cooldown gating, and sparse logging without per-hit noise.

Phase 3: Headless debug-input coverage exercised tower/enemy spawning and F10 captures; debug logs recorded tower creation and target deaths without attack-log spam. The user subsequently confirmed the required manual test passed.
